### PR TITLE
Add Many Faces of Sam artifact page to blog

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ about-author:   You found me. Why'd you have to wait to find me?
 # Social settings
 social-chatgpt: chatgpt
 social-newyear: newyear
+social-sam: sam
 
 
 # Newsletter

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -36,7 +36,7 @@ layout: default
   <div class="c-sidebar-footer">
     <div class="c-social">
       <div class="c-social__title">Social</div>
-        | <a href="{{site.social-chatgpt}}" target="_blank">ChatGPT</a> | <a href="{{site.social-newyear}}" target="_blank">NewYear</a> |
+        | <a href="{{site.social-chatgpt}}" target="_blank">ChatGPT</a> | <a href="{{site.social-newyear}}" target="_blank">NewYear</a> | <a href="{{site.social-sam}}" target="_blank">Sam</a> |
     </div>
     <div class="c-copyright">
       <p>{{site.time | date: '%Y'}} &copy; {{site.author-name}}</p>

--- a/sam/index.html
+++ b/sam/index.html
@@ -1,0 +1,742 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Many Faces of Sam · Winter Sun</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700;1,900&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=Special+Elite&family=Noto+Serif+SC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  html, body { margin: 0; padding: 0; }
+  body { background: #1a1410; }
+  *, *::before, *::after { box-sizing: border-box; }
+  button { font-family: inherit; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+<script type="text/babel" data-presets="react">
+const { useEffect } = React;
+
+const DIMS = [
+  { key: "burn",    cn: "燃烧", en: "BURN" },
+  { key: "drift",   cn: "漂泊", en: "DRIFT" },
+  { key: "silence", cn: "隐忍", en: "SILENCE" },
+  { key: "romance", cn: "浪漫", en: "ROMANCE" },
+  { key: "edge",    cn: "危险", en: "EDGE" },
+];
+
+const characters = [
+  {
+    id: "buck",
+    name: `Buck "The Kid"`,
+    film: "Box of Moonlight",
+    filmCN: "《月光宝盒》",
+    year: "1996",
+    tagline: "他像一只大狗，一旦认准你，就再也不肯走开。",
+    desc: `他住在森林深处一个堆满破烂的窝里，鹿皮衣、浣熊帽，整个人像从一个失落的世纪里掉出来的。可他眼睛亮得像夜里的两颗星，扑过来贴你的样子，是世上最毫无算计的喜欢。他会因为一片云走神，会因为一只虫子兴奋半天，会在你心情不好的时候默默地坐在你旁边——不说话，但身体的温度比任何安慰都暖。和他在一起，你会重新学会一件你早就忘了的事：爱不需要理由、不需要交换、不需要担心明天。它就是这样毛茸茸地、笨拙地、不顾一切地扑向你，然后，赖着不走。`,
+    bg: "#1a2418", accent: "#b8c878", text: "#e8eed8", muted: "#7a8868",
+    profile: { burn: 7, drift: 9, silence: 2, romance: 6, edge: 3 },
+  },
+  {
+    id: "trent",
+    name: "Trent",
+    film: "Lawn Dogs",
+    filmCN: "《割草叔叔》",
+    year: "1997",
+    tagline: "他不属于这里，但他愿意为你停下来。",
+    desc: `他像一阵从远方吹来的风，在这个不接纳他的小镇上停留得心不甘情不愿——直到他遇见你。他不擅长解释自己，他从小就习惯被误解、被驱逐、被那些自以为是的目光打量。可他在你面前会忽然安静下来，会把他偷偷搭建的那个属于他自己的小王国指给你看，会用一种近乎虔诚的方式守护一些他从来不曾对别人显露过的柔软。和他在一起，你会一点一点明白：原来"被看见"是一件多么稀罕的事。原来一个习惯了独自漂泊的人，会因为另一个孤独的灵魂而第一次想要停下脚步、第一次愿意承认"这里有我想留下的人"。你们的爱是世界对两个被放逐者罕有的好意——不响亮，可一旦发生，便足以替彼此抵挡掉所有过去的寒冷。`,
+    bg: "#1c2418", accent: "#c8a052", text: "#e8e0c8", muted: "#7a7654",
+    profile: { burn: 4, drift: 9, silence: 8, romance: 7, edge: 4 },
+  },
+  {
+    id: "samuel",
+    name: "Samuel",
+    film: "Safe Men",
+    filmCN: "《冒牌高手》",
+    year: "1998",
+    tagline: "他笨手笨脚，可你看一眼就想保护他。",
+    desc: `他是你这辈子见过最没有杀伤力的男人——唱歌走调，撬不开任何锁，连黑帮老大都能把他唬得团团转。可他对世界毫无防备的那种透明，会让你的心忽然软下来。他笑起来像把所有快乐都摊开给你看，他失落的时候那种垂头丧气的样子让你想立刻把他抱进怀里。和他在一起，你不会赢得人生的任何战役，但你会在每一个普通的傍晚都想要回家，因为家里有一个会因为你回来而眼睛发亮的人。你们的爱是傻气的、明亮的、毫无算计的——就像两个在世界上找到了彼此的笨拙小孩，再也不愿意分开。`,
+    bg: "#2a201a", accent: "#e8b89a", text: "#f0e2d4", muted: "#a08770",
+    profile: { burn: 3, drift: 3, silence: 2, romance: 6, edge: 1 },
+  },
+  {
+    id: "frank",
+    name: "Frank Mercer",
+    film: "Matchstick Men",
+    filmCN: "《火柴人》",
+    year: "2003",
+    tagline: `他撒了三年谎，但"我爱你"那句是真的。`,
+    desc: `他是那种你介绍给闺蜜会被嫌弃、自己却沦陷的男人——油腔滑调、举止轻浮、永远显得不太正经。和他在一起的每一天都太美好了，美好到你心底有一个细小的声音在提醒你：这一切是不是太像排练过的？等你终于看穿真相的那个夜晚，你以为这就是终场。可他会在某个你不抱希望的时刻回到你身边——没有西装、没有花言巧语、甚至来不及准备一句像样的台词，只是低声告诉你："我演过那么多场戏，可唯独你那段，我演不下去。"和他在一起，你会经历世上最华丽的骗局，也会收到一个骗子这辈子最赤裸的告白。你们的爱开场是一场精心设计的梦，可当他取下面具时，那双眼睛里的颤抖，是这场梦里唯一一件真的事。`,
+    bg: "#1f1822", accent: "#d680a5", text: "#ede0e6", muted: "#9a7088",
+    profile: { burn: 5, drift: 6, silence: 3, romance: 7, edge: 8 },
+  },
+  {
+    id: "jim",
+    name: "Jim Crocker",
+    film: "Piccadilly Jim",
+    filmCN: "《花花公子吉米》",
+    year: "2004",
+    tagline: "他用最绅士的方式把你逗笑。",
+    desc: `他风度翩翩，机智得让人警惕——和他对话像在打一场永远占下风的羽毛球，每一句俏皮话背后都藏着三层意思。可你慢慢会发现，他所有的玩笑、所有的伪装、所有戴着面具的周旋，都是为了在某个最不防备的时刻郑重地说出一句真心话。和他在一起，每一天都像活在一出莎士比亚喜剧里——误会、巧合、错位、突如其来的告白，让你又笑又恼又心动。你们的爱是一场盛大的化装舞会，他换了无数张面具陪你跳完整夜，到最后烛光将熄的时候，他终于在你面前摘下所有伪装——眼睛里写满郑重，像在说："这个，才是我准备给你看的样子。"`,
+    bg: "#2a1d24", accent: "#d4a4a8", text: "#f0e3dc", muted: "#95757e",
+    profile: { burn: 6, drift: 5, silence: 4, romance: 8, edge: 3 },
+  },
+  {
+    id: "brad",
+    name: "Brad Cairn",
+    film: "Joshua",
+    filmCN: "《约书亚》",
+    year: "2007",
+    tagline: "他独自看清，独自承担。",
+    desc: `他是那种把"守护"刻进骨子里的人——你还没察觉到风险，他已经替你布好后路；你还没说出疲惫，他已经悄悄替你扛了一半。和他在一起，你会感到一种奇异的安全感：哪怕全世界都站到他的对立面，他也不会松开你的手。他不会向你诉苦——他不擅长那种事，他从小就以为爱意必须沉默。可他疲惫到极致的样子会不小心被你撞见——深夜的客厅、独自冲一杯咖啡、肩膀微微塌下来的那个瞬间。那一刻你会忽然明白他对你的爱有多重：他不是不痛，他只是不愿意让你看见。你们的爱是城市最高楼里两盏亮到天明的灯，是即便孤立无援、即便整个世界都在崩塌，也要把你和你最在意的人，安安全全地送到岸上的那种承诺。`,
+    bg: "#1c2230", accent: "#d4a878", text: "#e8e3d8", muted: "#7a8590",
+    profile: { burn: 3, drift: 2, silence: 8, romance: 6, edge: 2 },
+  },
+  {
+    id: "glenn",
+    name: "Glenn Marchand",
+    film: "Snow Angels",
+    filmCN: "《雪天使》",
+    year: "2007",
+    tagline: "那一夜的雪地里，是你抓住了他的手。",
+    desc: `那一夜你不知道自己是怎么出现在那片雪地里的——只记得你看见他举着枪，眼神空得像一口井，前妻在他面前跪着发抖。所有人都觉得他没救了。可你冲过去抱住了他的手臂，死死不放，他愤怒地想挣脱，咒骂、撕扯、用尽全力——直到他低头看见你被他撞得发青的胳膊，整个人忽然像断了线一样僵在原地。Annie趁机跑掉了。雪地里只剩下他和你，和他抖得不成样子的呼吸。从那一夜开始，你成了他唯一不敢失去的人。他戒酒戒得像在剥自己的皮，他每一次崩溃前都先看你一眼，他第一次在午夜惊醒后哭出声、是因为梦见自己又举起了枪。和他在一起，你不会拥有一段轻松的爱情——你拥有的是一个被你从悬崖边拉回来的人，把他往后的每一天，都当成你给他的礼物来活。你们的爱是一个差点坠落的灵魂，被你的体温焊回了人间。`,
+    bg: "#1c2030", accent: "#e8c878", text: "#ebe4d8", muted: "#7a8090",
+    profile: { burn: 8, drift: 5, silence: 3, romance: 6, edge: 7 },
+  },
+  {
+    id: "victor",
+    name: "Victor Mancini",
+    film: "Choke",
+    filmCN: "《窒色》",
+    year: "2008",
+    tagline: "他知道自己是个混蛋，可他真心想成为不是混蛋的那个人。",
+    desc: `他白天在殖民时代主题公园扮演契约佣工，晚上去性瘾互助小组——主要是为了搭讪。他靠在餐厅假装噎住、让陌生人救他来骗钱，攒钱给痴呆的母亲付账单。你看他的简历会立刻把他拉黑，可你看他的眼睛会忽然明白：他是一个被遗弃太久、所以拼命寻求被需要的男孩。他用性、用谎言、用每一个边缘的把戏确认自己还活着、还被人记住。可当你出现的时候，他第一次想做一件从没做过的事——不是骗你、不是赢你、不是逃跑，而是停下来，让你看见他。和他在一起，你会经历他最坏的版本，也会见证一场缓慢、真实、他自己都不敢相信的救赎。这种爱不是闪电，是一棵被烧过的树，重新发芽。`,
+    bg: "#2a1820", accent: "#d49060", text: "#f0e0d4", muted: "#9a7868",
+    profile: { burn: 7, drift: 6, silence: 3, romance: 6, edge: 8 },
+  },
+  {
+    id: "sam",
+    name: "Sam Bell",
+    film: "Moon",
+    filmCN: "《月球》",
+    year: "2009",
+    tagline: "他在月球上，还想着给你做早餐。",
+    desc: `他是那种把"惦记你"刻进每一个清晨的男人。咖啡里要不要加糖、你昨天说过想吃什么、你今天穿这件会不会冷——这些他从来不会忘。和他在一起，每一个普通的早晨都会变成值得珍藏的瞬间：一杯调好温度的咖啡、随手贴在冰箱上的便条、一个回头时的拥抱。他不擅长用很大的话表达爱，他只是用一千个小动作把"我爱你"翻译成你能听懂的、最温暖的方言。最让人心碎的是——即便相隔三十八万公里，即便他自己都开始怀疑这个世界的真实性，他想起你的时候眼神还是亮的。你们的爱稳定得像月相，从不缺席；它不会让你心跳加速，但它会让你每一天都觉得：被这样一个人记着，真好。`,
+    bg: "#162038", accent: "#7eb0d5", text: "#e8eef5", muted: "#6a85a3",
+    profile: { burn: 4, drift: 1, silence: 5, romance: 9, edge: 1 },
+  },
+  {
+    id: "robert",
+    name: "Robert Goode",
+    film: "Everybody's Fine",
+    filmCN: "《天伦之旅》",
+    year: "2009",
+    tagline: "他对自己很苛刻，对你不会。",
+    desc: `他是那个一直被期待"还可以更好一点"的孩子。父亲想让他指挥乐团，他却只是乐团里安静敲鼓的那一个；他从小学会把失落折叠得很小，藏进西装内袋里，不让任何人看见。可你出现以后，那些他从没向任何人展示过的褶皱，会一层一层在你面前打开。他会记得你某天随口说过想吃的那家店，会在你失败的夜里只是握住你的手——什么都不评价，什么都不催促。你们的爱从来不轰烈，它像一架老钢琴的某根弦，被轻轻按下去时才发出声音，可那声音，会留在你心里很久很久。`,
+    bg: "#241c14", accent: "#c8a060", text: "#ede4d4", muted: "#9a7e58",
+    profile: { burn: 4, drift: 5, silence: 7, romance: 5, edge: 2 },
+  },
+  {
+    id: "kenny",
+    name: "Kenny Waters",
+    film: "Conviction",
+    filmCN: "《定罪》",
+    year: "2010",
+    tagline: "他生猛、暴躁，可笑起来像个孩子。",
+    desc: `他是那种你妈妈警告过你、你姐姐替你担心、你朋友拉着你别靠近的男人——脾气坏、嘴巴脏、喝多了爱惹事。可一旦他认你为重要的人，他会用一种让你心惊的诚意把你护住。他会为你和全世界吵架，然后回家用最温柔的方式给你倒一杯水；他会用最粗的话骂出最深的爱意，让你又想揍他又想抱他。和他在一起，你会经历无数次摔门、无数次和好；可你也会发现一件让你无法转身的事——他从不在你面前撒谎，哪怕真相会把他自己钉在墙上。最让人心碎的是他笑起来的样子——那么大的一个人，眼睛会亮得像个小男孩，仿佛被这个世界揍得遍体鳞伤之后，他还为你保留了一小块没被磨损的天真。你们的爱不优雅，但它比任何美好的言情都更诚实——是粗糙的、滚烫的、咬到见血但绝不撒手的那种。`,
+    bg: "#2a1614", accent: "#c75a3e", text: "#f0e0d4", muted: "#9a6858",
+    profile: { burn: 8, drift: 4, silence: 3, romance: 6, edge: 6 },
+  },
+  {
+    id: "billy",
+    name: "Billy Bickle",
+    film: "Seven Psychopaths",
+    filmCN: "《七个神经病》",
+    year: "2012",
+    tagline: "他会拉你做一百件不该做的事，然后你笑到肚子痛。",
+    desc: `他是那种走进你生活就把所有规矩搅烂的人——凌晨三点叫你起床去看流星，把最离谱的玩笑变成最郑重的告白，在你以为会很严肃的场合突然让你笑出声。和他在一起，你会发现你以前那种"循规蹈矩的快乐"其实根本不算快乐——他给你的是另一种，是放肆的、不要命的、一边奔跑一边大笑的那种。他疯，但他疯得只为你；他不正经，但他比任何正经人都把你当回事。最让人无可救药的是他看你的眼神——他可以对全世界开玩笑，但他从不开关于你的玩笑。你们的爱是一场永不结束的恶作剧，是他这辈子做过最认真的一件事。`,
+    bg: "#321a0a", accent: "#e8a04c", text: "#f5e6d0", muted: "#b07840",
+    profile: { burn: 9, drift: 9, silence: 1, romance: 5, edge: 9 },
+  },
+  {
+    id: "owen",
+    name: "Owen",
+    film: "The Way Way Back",
+    filmCN: "《迷途知返》",
+    year: "2013",
+    tagline: "他能把最糟的暑假变成你这辈子最难忘的。",
+    desc: `他看起来是那种对什么都不太上心的人——吊儿郎当、嘴上没正经、像永远也不会真正长大。可他有一种神奇的能力：能在你最想从这个世界消失的时候，准确地找到你，然后给你一个属于你的位置。和他在一起，你会重新觉得自己是值得被认真对待的——不是因为你做对了什么、不是因为你足够漂亮足够优秀，只是因为你是你。他不会用力承诺什么，他从不说那些大话；他只是会在每一个你以为自己又被忽略的瞬间，递给你一根冰棍、一个玩笑、一个让你偷偷红了眼眶的眼神。你们的爱是一个被晒得褪色的夏天，是关了灯还在轻轻发光的水池，是很多年以后你回想起来还会笑出声的——那个让你重新喜欢自己的男孩。`,
+    bg: "#1c2e36", accent: "#e8a880", text: "#ede4d4", muted: "#75899a",
+    profile: { burn: 5, drift: 4, silence: 3, romance: 4, edge: 2 },
+  },
+  {
+    id: "john",
+    name: "John Moon",
+    film: "A Single Shot",
+    filmCN: "《致命一击》",
+    year: "2013",
+    tagline: "他不说，但他每件事都为你做了。",
+    desc: `他话不多，眼神里藏着说不出口的过去——那种从年轻时就开始独自承受的、被生活揍得不愿意再开口的沉默。和他在一起的日子像冬日山林里的一炉火，你听不见火焰说话，可它整夜整夜地燃烧，足以替你抵挡所有寒冷。他从不擅长承诺，他甚至不知道怎么开口说"我爱你"——可你会发现，所有重要的事他都已经默默替你做完了：你冷的时候你身上多了一件外套，你饿的时候桌上有热的东西，你怕的时候他的身体已经站在你和危险之间。最让人想哭的是他偶尔看你的那种眼神——不带任何修饰，像是在说"你是这个糟糕世界里我唯一不想搞砸的事"。你们的爱是冷雾里伸出的一只手，不需要言语，不需要解释，只需要握紧——握紧之后，你就明白他这一辈子要交付给你的，是什么样的分量。`,
+    bg: "#1f2520", accent: "#9aa085", text: "#e8e3d6", muted: "#7d8270",
+    profile: { burn: 3, drift: 5, silence: 9, romance: 6, edge: 5 },
+  },
+  {
+    id: "craig",
+    name: "Craig",
+    film: "Laggies",
+    filmCN: "《迟来的告白》",
+    year: "2014",
+    tagline: "他是个离婚律师，可他从没放弃相信爱情。",
+    desc: `他每天的工作是帮别人结束婚姻——签字、分财产、看一对一对的人从对面走出去。他自己也是离了的，独自把女儿带大，习惯了用毒舌当盔甲，遇到不顺眼的事先损一句，遇到不顺眼的人直接挑眉。可你慢慢会发现，他的刻薄是一层壳，壳里面是一个还固执地相信爱情的男人——只是他不告诉任何人。和他在一起，你会被他那种"成年人的笨拙"打动：他装作不在意你，却记得你说过的每一句话；他试图把你推远，却在你需要的时候第一个出现在门口。你们的爱开始得不像样子，可正是因为他见过那么多坏的结局，他对你这一段，才比谁都郑重。`,
+    bg: "#241a14", accent: "#c89060", text: "#ede0d0", muted: "#a07858",
+    profile: { burn: 5, drift: 2, silence: 5, romance: 6, edge: 3 },
+  },
+  {
+    id: "francis",
+    name: "Francis Munch",
+    film: "Mr. Right",
+    filmCN: "《真命天子》",
+    year: "2015",
+    tagline: "他危险，但他记得你喜欢哪种花。",
+    desc: `他优雅、古怪、危险又浪漫——是那种你明知道应该躲开却忍不住一步步走近的男人。和他在一起，你会发现自己被他的目光重新校准过：他记得你提过的每一种偏好，记得你随口说过的每一首歌，记得你以为根本不会有人在意的那些小细节。他会在你完全没有察觉的地方为你扫清麻烦，会把最郑重的仪式感留给最无人在意的时刻。最让人沦陷的是他爱你的方式——他对世界冷酷、对暴力坦荡，可他对你温柔得近乎神圣，仿佛你是他这个混乱人生里唯一能称之为"道德"的东西。你们的爱是一场审美的共谋，是世界尽头的双人舞——他危险，他疯狂，他不属于任何安全的世界——可只要你伸出手，他会用他最危险的本事，把你护成全世界最被珍视的人。`,
+    bg: "#241432", accent: "#c9a0dc", text: "#ede4f2", muted: "#8b6ea0",
+    profile: { burn: 5, drift: 6, silence: 6, romance: 9, edge: 9 },
+  },
+  {
+    id: "dixon",
+    name: "Dixon",
+    film: "Three Billboards Outside Ebbing, Missouri",
+    filmCN: "《三块广告牌》",
+    year: "2017",
+    tagline: "他会为你打架，也会笨拙地为你写道歉信。",
+    desc: `他是Sam所有角色里最不像情人、却最容易让人爱到无法自拔的一个。他笨拙、暴躁、做事不过脑子；他把每一件本来可以做好的事都搞砸；他会在最不该说话的时候开口，又在最该开口的时候沉默。可你和他在一起的每一个瞬间，都能看见他在挣扎着想变好——为了你。他会在和你大吵之后一整夜睡不着，第二天清晨笨拙地敲你的门、手里攥着一封写得乱七八糟的道歉信；他会在最不浪漫的时刻说出最郑重的话，眼神里那种孤注一掷的真诚，会让你忽然原谅他做过的所有蠢事。最让人无法转身的是他被你看穿的样子——那个一直假装强硬的男人，会在你面前红了眼眶却不肯掉下来。你们的爱不是相遇，是互相点燃；不是岁月静好，是两个不完美的人决定一起去成为更好的人。这种爱不会让你舒服，但它会让你这一辈子，再也找不到比它更滚烫的东西。`,
+    bg: "#2a1410", accent: "#d97742", text: "#f5e6d3", muted: "#a87858",
+    profile: { burn: 9, drift: 3, silence: 3, romance: 5, edge: 7 },
+  },
+  {
+    id: "hendrix",
+    name: "Captain Klenzendorf",
+    film: "Jojo Rabbit",
+    filmCN: "《乔乔的异想世界》",
+    year: "2019",
+    tagline: "他从不说我爱你，但他用生命爱你。",
+    desc: `他是那种把所有真心都包在玩笑底下的人。他用讥诮和漫不经心当盔甲，看起来对什么都不在乎——你甚至会怀疑他到底有没有认真喜欢过你。可在某个你完全没有防备的瞬间，你会忽然明白：他对你的好，从来不在嘴上，全在那些他做了却不告诉你的事里。他会在最关键的时刻替你做出最沉重的决定，不需要你知道，也不指望你回报。和他在一起，你会经历一种奇怪的、迟到的心动——不是当下他逗你笑的那一刻，而是很久很久以后，当你回过头去，才发现他每一次"无所谓"的背后，都站着一个把你护在身后的人。你们的爱是不必说出口的暗号，是一句永远没说出来、却被他用整个余生写完的"我爱你"。`,
+    bg: "#1c2820", accent: "#c4a94a", text: "#ede8d8", muted: "#8b7d4d",
+    profile: { burn: 4, drift: 4, silence: 8, romance: 4, edge: 5 },
+  },
+  {
+    id: "wolf",
+    name: "Mr. Wolf",
+    film: "The Bad Guys",
+    filmCN: "《坏蛋联盟》",
+    year: "2022",
+    tagline: "他做了一辈子坏事，因为你想第一次试试做好人。",
+    desc: `他是那种走进房间就让所有人安静下来的男人——噢，不，公狼——西装笔挺，嘴角带着一抹不正经的笑，仿佛整个世界都是他的牌局。他可以从你手中偷走戒指，再递回来一支花，露出最迷人的笑容然后消失在夜色里。可你会发现他在你面前会一点一点慢下来：他第一次愿意为某个人停留得比"潇洒"更久一点，他第一次想要听一句真心话超过想要一次完美的撤退。和他在一起，你不会期待他变成一个安分的人；你只会渐渐看清，他所有的狡黠、潇洒、漫不经心，最终都被一件事温柔地统一了——他想成为你能信任的那个人。而你心里也会悄悄萌生出一个最危险的想法：和他一起，浪迹天涯。你们的爱是夜色里两个不肯安分的灵魂终于互相认领，是他这一生做过最不像他、却最像爱情的事。`,
+    bg: "#161a26", accent: "#d4ad5c", text: "#ede6d8", muted: "#7a7d8a",
+    profile: { burn: 6, drift: 7, silence: 4, romance: 8, edge: 6 },
+  },
+  {
+    id: "stoppard",
+    name: "Inspector Stoppard",
+    film: "See How They Run",
+    filmCN: "《看他们如何逃之夭夭》",
+    year: "2022",
+    tagline: "他疲惫，但他从不糊弄你。",
+    desc: `他像一杯久泡的茶——表面苦涩，底下温热。他不是那种会用浪漫包装自己的男人，他被生活磨得太久了，连惊喜都拿不出几个像样的；可正因为如此，他给你的每一份温柔都显得格外珍贵。和他在一起，你会发现一种迟钝的、缓慢的、却深得让你想哭的好——他听你说话的时候眼睛是真的在看你，他笑起来的样子像是把好几年没用过的情绪一次拿出来给你看。他不会对你说漂亮话，可他会在你最低落的夜晚一直陪着你，不催不劝、只是让你的肩膀靠在他的肩膀上。最让人心动的是他眼神里那种重新开始相信什么的小心翼翼——这个男人破过那么多案子，最难的那一桩，是终于在你面前重新相信了温柔。你们的爱是雨夜里一盏没熄的灯，是两个被生活揉皱过的人，最终决定为彼此把日子重新熨平。`,
+    bg: "#1a1f2c", accent: "#d4a548", text: "#ebe2d4", muted: "#7c8090",
+    profile: { burn: 3, drift: 3, silence: 6, romance: 5, edge: 2 },
+  },
+  {
+    id: "aidan",
+    name: "Aidan Wilde",
+    film: "Argylle",
+    filmCN: "《阿盖尔：神秘特工》",
+    year: "2024",
+    tagline: `他叫你一声"kid"，你愿意为他做一切傻事。`,
+    desc: `他是真正的特工，可你第一次见他的时候，他穿着皱巴巴的T恤、头发乱得像被风吻过，眼神像一只刚睡醒的猫——和电影里那种发胶头特工完全是两个物种。他能在两秒里救你出局，又能在三秒里让你笑到肚子痛。最要命的是他叫你"kid"——不是轻佻的，是有点宠溺、有点叹气、像在说"你这小笨蛋，我拿你怎么办"的那种。和他在一起，每一秒都像在跳一支没排练过的双人舞，他永远比你快半拍接住你；每一次回头，你都会发现他已经在那里——不慌不忙，半笑不笑，眼神温柔得像他从一开始就准备好为你停下整个世界。`,
+    bg: "#15192a", accent: "#d4a058", text: "#ebe2d0", muted: "#7a7e90",
+    profile: { burn: 7, drift: 8, silence: 5, romance: 9, edge: 7 },
+  },
+  {
+    id: "manfromfuture",
+    name: "The Man from the Future",
+    film: "Good Luck, Have Fun, Don't Die",
+    filmCN: "《团战之夜》",
+    year: "2025",
+    tagline: "他试过117次救这个世界——你是他从未试过的那个变量。",
+    desc: `他穿着塑料雨衣冲进深夜的餐馆，胡子拉碴，眼神疯狂，胸前绑着一堆乱糟糟的电线，嘴里喊着"世界要完蛋了"。所有人都以为他是疯子。可他真的是从未来回来的——他已经试过117次，每一次都失败，每一次都从头来过，每一次都独自背着所有人会怎么死的记忆。和他在一起，你会一点点看见他疯狂底下那种宇宙级的孤独：他记得每一种结局，所以他不敢期待任何开始。可这一次，他在重启的循环里第一次愣住了——因为在他穿越过的所有时间线里，从没有过你。你不在他的剧本里，你不在他的预测里，你是这个崩坏宇宙里唯一的、温柔的故障。你们的爱是一个走过太多终点的人，第一次想要停下来。`,
+    bg: "#1a0e2a", accent: "#d460a0", text: "#ede0ec", muted: "#8868a0",
+    profile: { burn: 8, drift: 8, silence: 3, romance: 4, edge: 6 },
+  },
+];
+
+function MiniRadar({ profile, accent, muted, text }) {
+  const size = 280;
+  const center = size / 2;
+  const maxR = 95;
+  const labelR = 120;
+  const numDims = 5;
+
+  function getPoint(value, idx) {
+    const angle = (Math.PI * 2 * idx) / numDims - Math.PI / 2;
+    const r = (value / 10) * maxR;
+    return { x: center + r * Math.cos(angle), y: center + r * Math.sin(angle) };
+  }
+
+  function getLabelPoint(idx) {
+    const angle = (Math.PI * 2 * idx) / numDims - Math.PI / 2;
+    return {
+      x: center + labelR * Math.cos(angle),
+      y: center + labelR * Math.sin(angle),
+    };
+  }
+
+  const points = DIMS.map(function(d, i) { return getPoint(profile[d.key], i); });
+  const path = points.map(function(p, i) {
+    return (i === 0 ? "M" : "L") + " " + p.x.toFixed(1) + " " + p.y.toFixed(1);
+  }).join(" ") + " Z";
+
+  const gridLevels = [2.5, 5, 7.5, 10];
+
+  return (
+    <svg viewBox={"0 0 " + size + " " + size} style={{ width: "100%", maxWidth: "280px" }}>
+      {gridLevels.map(function(lv, i) {
+        const gp = DIMS.map(function(_, idx) {
+          const p = getPoint(lv, idx);
+          return (idx === 0 ? "M" : "L") + " " + p.x.toFixed(1) + " " + p.y.toFixed(1);
+        }).join(" ") + " Z";
+        return (
+          <path key={i} d={gp} fill="none" stroke={muted}
+            strokeOpacity={i === gridLevels.length - 1 ? 0.4 : 0.13}
+            strokeWidth="0.5"
+          />
+        );
+      })}
+
+      {DIMS.map(function(_, i) {
+        const p = getPoint(10, i);
+        return <line key={i} x1={center} y1={center} x2={p.x} y2={p.y}
+          stroke={muted} strokeOpacity={0.18} strokeWidth="0.5" />;
+      })}
+
+      <path d={path} fill={accent} fillOpacity="0.22" stroke={accent} strokeOpacity="0.7" strokeWidth="1.2" />
+
+      {points.map(function(p, i) {
+        return <circle key={i} cx={p.x} cy={p.y} r="2.5" fill={accent} />;
+      })}
+
+      {DIMS.map(function(d, i) {
+        const lp = getLabelPoint(i);
+        return (
+          <g key={i}>
+            <text x={lp.x} y={lp.y - 3} textAnchor="middle" fontSize="9"
+              fontFamily="'Special Elite', monospace" fill={muted} letterSpacing="2">
+              {d.en}
+            </text>
+            <text x={lp.x} y={lp.y + 9} textAnchor="middle" fontSize="11"
+              fontFamily="'Noto Serif SC', serif" fontWeight="500" fill={text}>
+              {d.cn} {profile[d.key]}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+function CharacterCard({ c, idx }) {
+  return (
+    <section
+      id={c.id}
+      style={{
+        minHeight: "100vh",
+        width: "100%",
+        padding: "60px 24px 80px",
+        position: "relative",
+        background: c.bg,
+        color: c.text,
+        fontFamily: "'Noto Serif SC', serif",
+        scrollSnapAlign: "start",
+      }}
+    >
+      <div style={{
+        position: "absolute", inset: 0, pointerEvents: "none", opacity: 0.2,
+        background: "radial-gradient(ellipse at center, transparent 30%, " + c.bg + " 100%)",
+      }} />
+
+      <div style={{ maxWidth: "28rem", margin: "0 auto", position: "relative", zIndex: 10 }}>
+        <div style={{ textAlign: "center", marginBottom: "20px" }}>
+          <p style={{
+            fontFamily: "'Special Elite', monospace",
+            color: c.muted,
+            fontSize: "0.65rem",
+            letterSpacing: "0.5em",
+            marginBottom: "4px",
+          }}>
+            ── PORTRAIT NO. {String(idx + 1).padStart(2, "0")} ──
+          </p>
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", gap: "10px", margin: "24px 0" }}>
+          <span style={{ flex: 1, height: "1px", background: c.accent, opacity: 0.4 }} />
+          <span style={{ color: c.accent, fontSize: "0.8rem" }}>✦</span>
+          <span style={{ flex: 1, height: "1px", background: c.accent, opacity: 0.4 }} />
+        </div>
+
+        <h2 style={{
+          textAlign: "center",
+          fontFamily: "'Playfair Display', serif",
+          fontStyle: "italic",
+          fontWeight: 900,
+          color: c.accent,
+          fontSize: "2.75rem",
+          lineHeight: 1.05,
+          margin: "0 0 14px 0",
+          letterSpacing: "-0.01em",
+        }}>
+          {c.name}
+        </h2>
+
+        <p style={{
+          textAlign: "center",
+          fontFamily: "'Playfair Display', serif",
+          fontStyle: "italic",
+          color: c.muted,
+          fontSize: "0.95rem",
+          margin: "0 0 4px 0",
+        }}>
+          from {c.film} ({c.year})
+        </p>
+        <p style={{ textAlign: "center", color: c.muted, fontSize: "0.85rem", marginBottom: "32px" }}>
+          {c.filmCN}
+        </p>
+
+        <p style={{
+          textAlign: "center",
+          fontFamily: "'Noto Serif SC', serif",
+          fontWeight: 500,
+          color: c.text,
+          fontStyle: "italic",
+          fontSize: "1.2rem",
+          lineHeight: 1.6,
+          marginBottom: "32px",
+          padding: "0 12px",
+        }}>
+          "{c.tagline}"
+        </p>
+
+        <div style={{ display: "flex", alignItems: "center", margin: "24px 0" }}>
+          <span style={{ flex: 1, height: "1px", background: c.accent, opacity: 0.25 }} />
+        </div>
+
+        <p style={{
+          color: c.text,
+          opacity: 0.92,
+          textIndent: "2em",
+          fontSize: "1rem",
+          lineHeight: 1.95,
+          marginBottom: "40px",
+        }}>
+          {c.desc}
+        </p>
+
+        <div style={{ marginTop: "32px", display: "flex", flexDirection: "column", alignItems: "center" }}>
+          <p style={{
+            fontFamily: "'Special Elite', monospace",
+            color: c.muted,
+            fontSize: "0.65rem",
+            letterSpacing: "0.3em",
+            marginBottom: "16px",
+          }}>
+            ── PROFILE ──
+          </p>
+          <MiniRadar profile={c.profile} accent={c.accent} muted={c.muted} text={c.text} />
+        </div>
+
+        <div style={{
+          marginTop: "40px",
+          textAlign: "center",
+          fontFamily: "'Playfair Display', serif",
+          fontStyle: "italic",
+          color: c.muted,
+          opacity: 0.5,
+          fontSize: "1.4rem",
+        }}>
+          ❦
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SamGallery() {
+  useEffect(function() {
+    // fonts are loaded via <link> in <head>; effect kept as a no-op to preserve original lifecycle
+  }, []);
+
+  function jumpTo(id) {
+    const el = document.getElementById(id);
+    if (el) el.scrollIntoView({ behavior: "smooth" });
+  }
+
+  return (
+    <div style={{ width: "100%", fontFamily: "'Noto Serif SC', serif" }}>
+      {/* COVER */}
+      <section style={{
+        minHeight: "100vh",
+        width: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "60px 24px",
+        position: "relative",
+        background: "radial-gradient(ellipse at center, #f0e3cc 0%, #d4bf9d 100%)",
+      }}>
+        <div style={{ maxWidth: "28rem", textAlign: "center", position: "relative", zIndex: 10 }}>
+          <div style={{
+            display: "flex", alignItems: "center", justifyContent: "center",
+            gap: "12px", marginBottom: "32px", color: "#5c2618",
+          }}>
+            <span style={{ display: "inline-block", height: "1px", width: "40px", background: "#5c2618" }} />
+            <span style={{ fontFamily: "'Special Elite', monospace", fontSize: "0.65rem", letterSpacing: "0.4em" }}>
+              A FAN'S COMPENDIUM
+            </span>
+            <span style={{ display: "inline-block", height: "1px", width: "40px", background: "#5c2618" }} />
+          </div>
+
+          <p style={{
+            fontFamily: "'Special Elite', monospace",
+            color: "#7a3a26",
+            fontSize: "0.7rem",
+            letterSpacing: "0.5em",
+            marginBottom: "32px",
+          }}>
+            BY 冬璇 · WINTER SUN
+          </p>
+
+          <h1 style={{
+            fontFamily: "'Playfair Display', serif",
+            fontWeight: 900,
+            fontStyle: "italic",
+            color: "#2a1410",
+            fontSize: "3.2rem",
+            lineHeight: 1.05,
+            margin: "0 0 8px 0",
+          }}>
+            Many Faces
+          </h1>
+          <h1 style={{
+            fontFamily: "'Playfair Display', serif",
+            fontWeight: 900,
+            fontStyle: "italic",
+            color: "#2a1410",
+            fontSize: "3.2rem",
+            lineHeight: 1.05,
+            margin: "0 0 32px 0",
+          }}>
+            of Sam
+          </h1>
+
+          <p style={{ color: "#3a1f15", fontSize: "1.1rem", marginBottom: "8px", letterSpacing: "0.05em" }}>
+            他 的 种 种 样 子
+          </p>
+
+          <div style={{
+            display: "flex", alignItems: "center", justifyContent: "center",
+            gap: "8px", margin: "32px 0", color: "#7a3a26",
+          }}>
+            <span>✦</span><span>✦</span><span>✦</span>
+          </div>
+
+          <p style={{
+            color: "#3a1f15",
+            fontSize: "0.95rem",
+            lineHeight: 1.8,
+            marginBottom: "24px",
+          }}>
+            每一部电影 · 一种爱<br />
+            一个粉丝写给他角色的情书集
+          </p>
+
+          <p style={{
+            fontFamily: "'Playfair Display', serif",
+            fontStyle: "italic",
+            color: "#5c2618",
+            fontSize: "0.95rem",
+            lineHeight: 1.8,
+            marginTop: "48px",
+            marginBottom: "48px",
+          }}>
+            "He walks across the screen,<br />
+            and stops in front of you."
+          </p>
+
+          {/* TOC */}
+          <div style={{
+            marginTop: "48px",
+            paddingTop: "32px",
+            borderTop: "1px solid #7a3a26",
+          }}>
+            <p style={{
+              fontFamily: "'Special Elite', monospace",
+              fontSize: "0.7rem",
+              color: "#7a3a26",
+              letterSpacing: "0.3em",
+              marginBottom: "20px",
+            }}>
+              ── CONTENTS ──
+            </p>
+            <div style={{ display: "flex", flexDirection: "column", gap: "10px", textAlign: "left" }}>
+              {characters.map(function(c, i) {
+                return (
+                  <button
+                    key={c.id}
+                    onClick={function() { jumpTo(c.id); }}
+                    style={{
+                      display: "flex",
+                      alignItems: "baseline",
+                      gap: "12px",
+                      padding: "8px 4px",
+                      background: "transparent",
+                      border: "none",
+                      borderBottom: "1px dotted #a8896a",
+                      color: "#2a1410",
+                      cursor: "pointer",
+                      fontFamily: "'Noto Serif SC', serif",
+                      textAlign: "left",
+                      width: "100%",
+                    }}
+                  >
+                    <span style={{
+                      fontFamily: "'Special Elite', monospace",
+                      fontSize: "0.7rem",
+                      color: "#7a3a26",
+                      width: "30px",
+                      flexShrink: 0,
+                    }}>
+                      {String(i + 1).padStart(2, "0")}
+                    </span>
+                    <span style={{
+                      fontFamily: "'Playfair Display', serif",
+                      fontStyle: "italic",
+                      fontSize: "1rem",
+                      color: "#2a1410",
+                      flex: 1,
+                    }}>
+                      {c.name}
+                    </span>
+                    <span style={{
+                      fontFamily: "'Special Elite', monospace",
+                      fontSize: "0.7rem",
+                      color: "#7a3a26",
+                    }}>
+                      {c.year}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <p style={{
+            fontFamily: "'Special Elite', monospace",
+            color: "#7a3a26",
+            fontSize: "0.65rem",
+            marginTop: "40px",
+            letterSpacing: "0.2em",
+            opacity: 0.7,
+          }}>
+            ▼ 向下滑动开始 ▼
+          </p>
+        </div>
+      </section>
+
+      {/* CHARACTER CARDS */}
+      {characters.map(function(c, i) {
+        return <CharacterCard key={c.id} c={c} idx={i} />;
+      })}
+
+      {/* CLOSING */}
+      <section style={{
+        minHeight: "70vh",
+        width: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "80px 24px",
+        background: "radial-gradient(ellipse at center, #f0e3cc 0%, #d4bf9d 100%)",
+      }}>
+        <div style={{ maxWidth: "28rem", textAlign: "center" }}>
+          <div style={{
+            display: "flex", alignItems: "center", justifyContent: "center",
+            gap: "8px", marginBottom: "32px", color: "#7a3a26",
+          }}>
+            <span>✦</span><span>✦</span><span>✦</span>
+          </div>
+
+          <p style={{
+            fontFamily: "'Playfair Display', serif",
+            fontStyle: "italic",
+            color: "#2a1410",
+            fontSize: "1.6rem",
+            lineHeight: 1.5,
+            marginBottom: "24px",
+          }}>
+            "He's never just one person.<br />
+            He's many—and you<br />
+            love them all."
+          </p>
+
+          <p style={{
+            color: "#3a1f15",
+            fontSize: "0.95rem",
+            lineHeight: 1.8,
+            marginBottom: "48px",
+            opacity: 0.85,
+          }}>
+            从1997到2022<br />
+            他演过那么多人<br />
+            而每一个，都让你心动过
+          </p>
+
+          <button
+            onClick={function() { window.scrollTo({ top: 0, behavior: "smooth" }); }}
+            style={{
+              background: "transparent",
+              color: "#5c2618",
+              fontFamily: "'Special Elite', monospace",
+              letterSpacing: "0.3em",
+              fontSize: "0.8rem",
+              border: "1px solid #5c2618",
+              padding: "12px 32px",
+              cursor: "pointer",
+            }}
+          >
+            ↑ 回到目录
+          </button>
+
+          <p style={{
+            fontFamily: "'Special Elite', monospace",
+            color: "#7a3a26",
+            fontSize: "0.7rem",
+            marginTop: "48px",
+            letterSpacing: "0.4em",
+            opacity: 0.7,
+          }}>
+            ✦ FIN ✦
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<SamGallery />);
+</script>
+</body>
+</html>


### PR DESCRIPTION
- New self-contained React (UMD + Babel standalone) page at /sam/
  rendering the 22-character "Many Faces of Sam" gallery with the
  original cover, per-character cards, mini radar charts and closing
  section, styling preserved verbatim.
- Hooks into existing sidebar Social row alongside ChatGPT and NewYear
  via new `social-sam` config key.

https://claude.ai/code/session_01SJfWjTWx1YddJ5SHbxiqfN