### PR TITLE
Remove CNAME so github.io URL serves directly

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-gitpage.wintersun.zone


### PR DESCRIPTION
Custom domain wintersun.zone has expired and the CNAME file was forcing GitHub Pages to redirect github.io traffic to the dead custom hostname. Removing it lets the project Pages site be reached at https://dxwintersun.github.io/WinterSunBlog/ until the domain is renewed (re-add a one-line CNAME at that point).

https://claude.ai/code/session_01SJfWjTWx1YddJ5SHbxiqfN