### PR TITLE
Pin CDN versions and cache-bust /sam/

### DIFF
--- a/sam/index.html
+++ b/sam/index.html
@@ -16,9 +16,10 @@
 </head>
 <body>
 <div id="root"></div>
-<script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+<meta name="cache-bust" content="2026-05-01-v2">
+<script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+<script crossorigin src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.24.7/babel.min.js"></script>
 <script type="text/babel" data-presets="react">
 const { useEffect } = React;
 


### PR DESCRIPTION
## Summary
- Pin React 18 and @babel/standalone to specific versions instead of `latest` — `@babel/standalone` without a version may have shipped a regression breaking inline JSX compilation.
- Add `<meta name="cache-bust">` to force a new ETag so any stale CDN/browser cache from the earlier broken deploy is bypassed.

## Test plan
- [ ] After deploy, hard-refresh `/sam/` and confirm gallery renders.

https://claude.ai/code/session_01RATiMHu6UUuTNLaASyAo8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01RATiMHu6UUuTNLaASyAo8y)_