### PR TITLE
Compute closing year range dynamically from characters data

### DIFF
--- a/sam/index.html
+++ b/sam/index.html
@@ -16,7 +16,7 @@
 </head>
 <body>
 <div id="root"></div>
-<meta name="cache-bust" content="2026-05-01-v3">
+<meta name="cache-bust" content="2026-05-01-v4">
 <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
 <script crossorigin src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
 <script src="https://unpkg.com/@babel/standalone@7.24.7/babel.min.js"></script>
@@ -1034,7 +1034,7 @@ function SamGallery() {
             marginBottom: "48px",
             opacity: 0.85,
           }}>
-            从1997到2022<br />
+            从{Math.min.apply(null, characters.map(function(c) { return parseInt(c.year, 10); }))}到{Math.max.apply(null, characters.map(function(c) { return parseInt(c.year, 10); }))}<br />
             他演过那么多人<br />
             而每一个，都让你心动过
           </p>

--- a/src/sam/sam_gallery.jsx
+++ b/src/sam/sam_gallery.jsx
@@ -904,7 +904,7 @@ export default function SamGallery() {
             marginBottom: "48px",
             opacity: 0.85,
           }}>
-            从1997到2022<br />
+            从{Math.min.apply(null, characters.map(function(c) { return parseInt(c.year, 10); }))}到{Math.max.apply(null, characters.map(function(c) { return parseInt(c.year, 10); }))}<br />
             他演过那么多人<br />
             而每一个，都让你心动过
           </p>


### PR DESCRIPTION
## Summary
- Replace hardcoded `从1997到2022` in the closing section with `Math.min`/`Math.max` over `characters[].year`, so the year range updates automatically when characters are added or removed
- Bump `cache-bust` meta to `2026-05-01-v4`

With current data the closing line will read `从1991到2025`.

Applied to both `src/sam/sam_gallery.jsx` (source-of-truth) and `sam/index.html` (the inline page actually served by GitHub Pages).

## Test plan
- [ ] After merge, wait for Pages workflow
- [ ] Hard-refresh `https://dxwintersun.github.io/WinterSunBlog/sam/?v=4`
- [ ] Confirm closing reads `从1991到2025`

https://claude.ai/code/session_0128JdEgyrEZvXEaGakG7ngt

---
_Generated by [Claude Code](https://claude.ai/code/session_0128JdEgyrEZvXEaGakG7ngt)_