### PR TITLE
Redesign homepage as magazine-style layout

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,9 +9,15 @@
         <li class="c-nav__item c-item_post is-active" data-filter="all">All</li>
         <li class="c-nav__item c-item_post" data-filter="Daily">Daily</li>
         <li class="c-nav__item c-item_post" data-filter="Novel">Novel</li>
+        <li class="c-nav__item c-item_post" data-filter="AU Story">AU Story</li>
         <li class="c-nav__item c-item_post" data-filter="Lyrics">Lyrics</li>
         <li class="c-nav__item c-item_images">Gallery</li>
-        <li class="c-nav__item c-item_tags">Tags</li>
+        <li class="c-nav__item c-nav__item--link">
+          <a href="{{site.baseurl}}/sam/">Sam</a>
+        </li>
+        <li class="c-nav__item c-nav__item--link">
+          <a href="{{site.baseurl}}/about/">About</a>
+        </li>
       </ul>
     </nav>
 

--- a/_includes/image-show.html
+++ b/_includes/image-show.html
@@ -1,91 +1,33 @@
 <div class="c-show-images" style="display: none;">
-  <div id="container">
+  <div class="c-section-heading">
+    <h3 class="c-section-heading__title">Gallery</h3>
+    <span class="c-section-heading__meta">{{ site.gallery_images.size }} pieces</span>
+  </div>
+
+  <div id="container" class="c-gallery">
     {% for image_paths in site.gallery_images %}
-    <div class="box">
-      <div class="box-img">
-        <img src="./images/{{ image_paths }}" alt="">
-      </div>
-    </div>
+    <a class="c-gallery__item" href="{{site.baseurl}}/images/{{ image_paths }}">
+      <img src="{{site.baseurl}}/images/{{ image_paths }}" alt="" loading="lazy">
+    </a>
     {% endfor %}
   </div>
-</div> <!-- ./c-blog-tags -->
+</div>
+
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.2/viewer.min.css">
-<style>
-  {
-    padding: 0;
-    margin: 0;
-  }
-
-  #container {
-    position: relative;
-  }
-
-  .box {
-    float: left;
-    padding: 15px;
-  }
-
-  .box-img {
-    width: 300px;
-    padding: 5px;
-    border: 1px solid #ccc;
-    box-shadow: 0 0 5px #ccc;
-    border-radius: 5px;
-  }
-
-  .box-img img {
-    width: 100%;
-    height: auto;
-  }
-</style>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.2/viewer.min.js"></script>
-
 <script>
-  var viewer = new Viewer(document.getElementById('container'));
-  window.onload = function () {
-    imgLocation('container', 'box')
-  }
-  // 获取到当前有多少张图片要摆放
-  function imgLocation(parent, content) {//令parent='container'，content='box'
-    // 将parent下所有的内容全部取出
-    var cparent = document.getElementById(parent)
-    var ccontent = getChildElemnt(cparent, content)
-    var imgWidth = ccontent[0].offsetWidth
-    var num = Math.floor(document.documentElement.clientWidth / imgWidth)
-    cparent.style.cssText = `width: ${imgWidth * num} px`
-
-    var BoxHeightArr = []
-    for (var i = 0; i < ccontent.length; i++) {
-      if (i < num) {
-        BoxHeightArr[i] = ccontent[i].offsetHeight
-      } else {
-        var minHeight = Math.min.apply(null, BoxHeightArr)
-        var minIndex = getMinHeightLocation(BoxHeightArr, minHeight)
-        ccontent[i].style.position = 'absolute'
-        ccontent[i].style.top = minHeight + 'px'
-        ccontent[i].style.left = ccontent[minIndex].offsetLeft + 'px'
-        BoxHeightArr[minIndex] = BoxHeightArr[minIndex] + ccontent[i].offsetHeight
-      }
+  (function () {
+    var initGallery = function () {
+      try {
+        if (typeof Viewer === 'function') {
+          new Viewer(document.getElementById('container'), { toolbar: false, navbar: true, title: false });
+        }
+      } catch (e) { /* swallow */ }
+    };
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initGallery);
+    } else {
+      initGallery();
     }
-  }
-
-
-  function getChildElemnt(parent, content) {
-    const contentArr = []
-    const allContent = parent.getElementsByTagName('*')
-    for (var i = 0; i < allContent.length; i++) {
-      if (allContent[i].className == content) {
-        contentArr.push(allContent[i])
-      }
-    }
-    return contentArr
-  }
-
-  function getMinHeightLocation(BoxHeightArr, minHeight) {
-    for (var i in BoxHeightArr) {
-      if (BoxHeightArr[i] === minHeight) {
-        return i
-      }
-    }
-  }
+  })();
 </script>

--- a/_pages/about/index.html
+++ b/_pages/about/index.html
@@ -1,0 +1,42 @@
+---
+layout: home
+title: About
+permalink: /about/
+---
+
+<section class="c-hero">
+  <div class="c-hero__eyebrow">About</div>
+  <h1 class="c-hero__title">Hi, I'm <em>{{ site.author-name }}</em></h1>
+  <p class="c-hero__lede">{{ site.about-author | strip_html }}</p>
+
+  <div class="c-hero__meta">
+    {% if site.author-image %}
+    <span class="c-hero__avatar">
+      <img src="{{site.baseurl}}/images/{{site.author-image}}" alt="{{site.author-name}}">
+    </span>
+    {% endif %}
+    <div class="c-hero__meta-text">
+      <div class="c-hero__meta-name">{{ site.author-name }}</div>
+      <div class="c-hero__meta-role">{{ site.author-job }}</div>
+    </div>
+  </div>
+
+  <div class="c-hero__socials">
+    {% if site.author-email %}<a href="/contact">Contact</a>{% endif %}
+    {% if site.author-weibo %}<a href="{{site.author-weibo}}" target="_blank" rel="noopener">Weibo</a>{% endif %}
+    {% if site.author-bilibili %}<a href="{{site.author-bilibili}}" target="_blank" rel="noopener">Bilibili</a>{% endif %}
+  </div>
+</section>
+
+<article class="c-about">
+  <p class="c-about__lede">
+    This is a quiet corner of the internet where I keep what matters to me —
+    daily notes, novels and AU stories I've written, lyric translations,
+    and pictures I've drawn or fallen in love with.
+  </p>
+
+  <p>
+    I write mostly in Chinese, sometimes in English, occasionally side by side.
+    I make things slowly. Thanks for stopping by.
+  </p>
+</article>

--- a/_sass/5-components/_content.scss
+++ b/_sass/5-components/_content.scss
@@ -9,12 +9,24 @@
 }
 
 .c-empty-state {
-  padding: 60px 20px;
+  padding: 80px 20px;
   text-align: center;
   color: $muted;
-  font-family: $heading-font-family;
-  font-style: italic;
-  font-size: 15px;
+  .c-empty-state__title {
+    font-family: $heading-font-family;
+    font-style: italic;
+    font-size: 22px;
+    color: $ink;
+    margin: 0 0 8px;
+  }
+  .c-empty-state__hint {
+    font-family: $heading-font-family;
+    font-size: 12px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: $muted;
+    margin: 0;
+  }
 }
 
 /* ===== Footer ===== */

--- a/_sass/5-components/_header.scss
+++ b/_sass/5-components/_header.scss
@@ -62,7 +62,6 @@
 
 .c-nav__item {
   position: relative;
-  padding: 8px 14px;
   font-family: $heading-font-family;
   font-size: 13px;
   letter-spacing: 0.06em;
@@ -72,6 +71,7 @@
   border-radius: 999px;
   transition: $global-transition;
   user-select: none;
+  padding: 8px 14px;
   &:hover {
     color: $accent;
     background-color: rgba(184, 92, 92, 0.06);
@@ -79,6 +79,25 @@
   &.is-active {
     color: $paper;
     background-color: $ink;
+  }
+  &.c-nav__item--link {
+    padding: 0;
+    background: transparent;
+    > a {
+      display: block;
+      padding: 8px 14px;
+      color: inherit;
+      text-decoration: none;
+      border-radius: 999px;
+      transition: $global-transition;
+    }
+    &:hover {
+      background: transparent;
+      > a {
+        color: $accent;
+        background-color: rgba(184, 92, 92, 0.06);
+      }
+    }
   }
 }
 

--- a/_sass/5-components/_hero.scss
+++ b/_sass/5-components/_hero.scss
@@ -124,6 +124,25 @@
   }
 }
 
+/* ===== About page prose ===== */
+.c-about {
+  max-width: 640px;
+  margin: 0 auto 80px;
+  padding: 0 8px;
+  font-size: 16px;
+  line-height: 1.85;
+  color: $ink-soft;
+  p { margin: 0 0 20px; }
+  .c-about__lede {
+    font-family: $heading-font-family;
+    font-size: 19px;
+    font-style: italic;
+    color: $ink;
+    line-height: 1.6;
+    margin-bottom: 28px;
+  }
+}
+
 /* ===== Section heading used above lists ===== */
 .c-section-heading {
   display: flex;

--- a/_sass/5-components/_index-post.scss
+++ b/_sass/5-components/_index-post.scss
@@ -218,6 +218,40 @@
 .c-post.is-hidden,
 .c-featured.is-hidden { display: none; }
 
+/* ----- Gallery (image grid) ----- */
+.c-gallery {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+
+.c-gallery__item {
+  display: block;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  border-radius: 4px;
+  background-color: $line;
+  box-shadow: 0 8px 22px -14px rgba(31, 29, 26, 0.25);
+  transition: $global-transition;
+  &:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 18px 36px -16px rgba(31, 29, 26, 0.35);
+  }
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+@media only screen and (max-width: 720px) {
+  .c-gallery {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+}
+
 /* Legacy load-more — kept */
 .c-load-more {
   display: block;

--- a/index.html
+++ b/index.html
@@ -79,7 +79,10 @@ layout: home
     {% endfor %}
   </div>
 
-  <div class="c-empty-state" data-empty hidden>Nothing here yet under this category.</div>
+  <div class="c-empty-state" data-empty hidden>
+    <p class="c-empty-state__title">Nothing filed here yet.</p>
+    <p class="c-empty-state__hint">This category is waiting for its first story.</p>
+  </div>
 
   {% else %}
   <div class="c-empty-state">Stories are on their way.</div>

--- a/js/main.js
+++ b/js/main.js
@@ -45,11 +45,18 @@ $(document).ready(function () {
         $(this).addClass('is-hidden');
       }
     });
-    $('[data-empty]').toggle(visible === 0 && filter !== 'all');
+    var isEmpty = visible === 0 && filter !== 'all';
+    $('[data-empty]').toggle(isEmpty);
+    // Hide the "More Stories" header when filtered set is empty or only featured remains
+    var gridVisible = $('.c-post-grid .c-post:not(.is-hidden)').length;
+    $('.c-section-heading').toggle(gridVisible > 0);
   }
 
-  $('.c-nav__list > .c-nav__item').on('click', function () {
+  $('.c-nav__list > .c-nav__item').on('click', function (e) {
     var $this = $(this);
+    // Real-link items navigate natively
+    if ($this.hasClass('c-nav__item--link')) return;
+
     $('.c-nav__list > .c-nav__item').removeClass('is-active');
     $this.addClass('is-active');
 
@@ -65,6 +72,11 @@ $(document).ready(function () {
     } else if ($this.hasClass('c-item_images')) {
       $('.c-show-images').show().addClass('o-opacity');
       $('.c-posts, .c-categories, .c-blog-tags').hide().removeClass('o-opacity');
+    }
+
+    // Scroll up so user sees the change
+    if ($('main.c-content').length && window.scrollY > 200) {
+      $('html, body').animate({ scrollTop: $('main.c-content').offset().top - 80 }, 250);
     }
   });
 


### PR DESCRIPTION
## Summary

Redesign the homepage from the old fixed-sidebar template into a calmer, magazine-style layout that better fits the journal's voice.

**Layout**
- Drop the 360px fixed sidebar; full-width content centred in a 1180px container
- Sticky top bar with brand mark, primary nav, and search
- Hero section with site title (italic accent on `'s Zone`), tagline, and author meta
- Latest post promoted as a featured card (large image + serif title + summary)
- Remaining posts in a 2-column grid

**Navigation**
Primary nav is now: **All · Daily · Novel · AU Story · Lyrics · Gallery · Sam · About**
- All / Daily / Novel / AU Story / Lyrics — in-place filter via `data-category`
- Gallery — toggles the existing image grid (rebuilt as a clean 3-column lightbox)
- Sam — real link to `/sam/`
- About — new placeholder page at `/about/`
- AU Story currently has no posts and shows a friendly empty state

**Visual**
- New palette: warm cream background (`#f7f3ec`), deep ink text, dusty rose accent (`#b85c5c`)
- Typography keeps Volkhov serif for display, adds Noto Serif SC / Songti SC fallback for Chinese
- Cards use 4px micro-rounding, soft shadow, hover lift + image zoom

**Robustness**
- Wrapped Viewer.js init in try/catch so a CDN miss no longer breaks click handlers
- Filter clicks gently scroll the post list into view so the change is obvious

## Test plan
- [ ] Verify topbar nav: each filter (Daily / Novel / AU Story / Lyrics) hides non-matching posts
- [ ] Verify Sam link navigates to `/sam/`
- [ ] Verify About link navigates to new `/about/` page
- [ ] Verify Gallery shows the 3-column image grid and the lightbox opens on click
- [ ] Verify search box still returns results
- [ ] Verify post detail pages still render correctly under new top bar
- [ ] Verify mobile layout (≤720px) — hero shrinks, grid collapses to one column

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_