### PR TITLE
Fix baseurl for GitHub Pages project subpath

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Winter Sun's Zone
 description: Winter Sun's Zone
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "wintersun.zone" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/WinterSunBlog" # the subpath of your site, e.g. /blog
+url: "https://dxwintersun.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Author
 author-name:    Winter Sun

--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -1,3 +1,4 @@
+<script>window.SITE_BASEURL = "{{site.baseurl}}";</script>
 <script src="{{site.baseurl}}/js/jquery-3.3.1.min.js"></script>
 <script src="{{site.baseurl}}/js/evil-icons.min.js"></script>
 <script src="{{site.baseurl}}/js/jquery.fitvids.js"></script>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -12,12 +12,12 @@ layout: default
 <footer class="c-footer">
   <div class="o-container">
     <div class="c-footer__links">
-      {% if site.social-chatgpt %}<a href="{{site.social-chatgpt}}" target="_blank" rel="noopener">ChatGPT</a>{% endif %}
-      {% if site.social-newyear %}<a href="{{site.social-newyear}}" target="_blank" rel="noopener">NewYear</a>{% endif %}
-      {% if site.social-sam %}<a href="{{site.social-sam}}" target="_blank" rel="noopener">Sam</a>{% endif %}
+      {% if site.social-chatgpt %}<a href="{{site.baseurl}}/{{site.social-chatgpt}}/" rel="noopener">ChatGPT</a>{% endif %}
+      {% if site.social-newyear %}<a href="{{site.baseurl}}/{{site.social-newyear}}/" rel="noopener">NewYear</a>{% endif %}
+      {% if site.social-sam %}<a href="{{site.baseurl}}/{{site.social-sam}}/" rel="noopener">Sam</a>{% endif %}
       {% if site.author-weibo %}<a href="{{site.author-weibo}}" target="_blank" rel="noopener">Weibo</a>{% endif %}
       {% if site.author-bilibili %}<a href="{{site.author-bilibili}}" target="_blank" rel="noopener">Bilibili</a>{% endif %}
-      {% if site.author-email %}<a href="/contact">Email</a>{% endif %}
+      {% if site.author-email %}<a href="{{site.baseurl}}/contact/">Email</a>{% endif %}
     </div>
     <div class="c-footer__copy">
       {{site.time | date: '%Y'}} &copy; {{site.author-name}} · {{site.title}}

--- a/_pages/about/index.html
+++ b/_pages/about/index.html
@@ -22,7 +22,7 @@ permalink: /about/
   </div>
 
   <div class="c-hero__socials">
-    {% if site.author-email %}<a href="/contact">Contact</a>{% endif %}
+    {% if site.author-email %}<a href="{{site.baseurl}}/contact/">Contact</a>{% endif %}
     {% if site.author-weibo %}<a href="{{site.author-weibo}}" target="_blank" rel="noopener">Weibo</a>{% endif %}
     {% if site.author-bilibili %}<a href="{{site.author-bilibili}}" target="_blank" rel="noopener">Bilibili</a>{% endif %}
   </div>

--- a/_pages/contact/index.html
+++ b/_pages/contact/index.html
@@ -18,7 +18,7 @@ permalink: /contact/
 <div class="c-form-box o-opacity">
   <form class="c-form" action="{% if site.author-email %}https://formspree.io/{{site.author-email}}{% else %}#{% endif %}"
     method="POST">
-    <a href="/"><div class="c-form-bnt__close" data-icon='ei-close' data-size='s'></div></a>
+    <a href="{{site.baseurl}}/"><div class="c-form-bnt__close" data-icon='ei-close' data-size='s'></div></a>
     <div class="c-form__title">You can contact me!</div>
     <div class="c-form__group">
       <label for="form-name">Your Name (Required)</label>

--- a/js/main.js
+++ b/js/main.js
@@ -10,7 +10,7 @@ $(document).ready(function () {
     SimpleJekyllSearch({
       searchInput: document.getElementById('js-search-input'),
       resultsContainer: document.getElementById('js-results-container'),
-      json: '/search.json',
+      json: (window.SITE_BASEURL || '') + '/search.json',
       searchResultTemplate: '<li><a href="{url}">{title}</a></li>',
       noResultsText: '<li><a>No results</a></li>'
     });
@@ -94,7 +94,7 @@ $(document).ready(function () {
 
     $(this).addClass('is-loading').text("Loading...");
 
-    $.get('/page/' + nextPage, function (data) {
+    $.get((window.SITE_BASEURL || '') + '/page/' + nextPage, function (data) {
       var htmlData = $.parseHTML(data);
       var $articles = $(htmlData).find('article');
 


### PR DESCRIPTION
## Summary

The site is hosted at the default GitHub Pages project URL `https://dxwintersun.github.io/WinterSunBlog/`, but `_config.yml` had `baseurl: ""` and pointed `url` at the now-expired `wintersun.zone`. As a result, every internal link (`/sam/`, `/about/`, `/js/main.js`, `/images/...`) resolved at `dxwintersun.github.io/...` (the github.io root), which has no Pages site, so clicks returned the generic GitHub 404.

## Fix

- `_config.yml`: `baseurl: "/WinterSunBlog"`, `url: "https://dxwintersun.github.io"`
- Footer / About: prefix `chatgpt`, `newyear`, `sam`, `/contact` links with `{{ site.baseurl }}`
- `main.js`: read `window.SITE_BASEURL` (set in `javascripts.html`) so the SimpleJekyllSearch JSON URL and the pagination `/page/N` URL pick up the prefix
- `contact/index.html`: prefix the close button's `/` link

## Test plan
- [ ] Visit https://dxwintersun.github.io/WinterSunBlog/ — homepage loads with images and JS
- [ ] Click **Sam** → loads `/WinterSunBlog/sam/`
- [ ] Click **About** → loads `/WinterSunBlog/about/`
- [ ] Filter chips (Daily / Novel / etc) still work (JS loaded)
- [ ] Search dropdown returns results (search.json found)
- [ ] Footer links (ChatGPT / NewYear / Sam) navigate inside `/WinterSunBlog/`

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_