### PR TITLE
Rename to Winter in Wonderland and redesign hero

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
-title: Winter Sun's Zone
-description: Winter Sun's Zone
+title: Winter in Wonderland
+description: Winter in Wonderland — a personal journal by 冬璇 · Winter Sun
 baseurl: "/WinterSunBlog" # the subpath of your site, e.g. /blog
 url: "https://dxwintersun.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header class="c-topbar">
   <div class="o-container c-topbar__inner">
     <a class="c-brand" href="{{site.baseurl}}/">
-      {{ site.title | replace: "'s Zone", "" }}<span class="c-brand__dot"></span>
+      <span class="c-brand__mark">W</span><span class="c-brand__rest">inter</span><span class="c-brand__dot"></span>
     </a>
 
     <nav class="c-nav" aria-label="Primary">

--- a/_pages/about/index.html
+++ b/_pages/about/index.html
@@ -5,21 +5,25 @@ permalink: /about/
 ---
 
 <section class="c-hero">
-  <div class="c-hero__eyebrow">About</div>
-  <h1 class="c-hero__title">Hi, I'm <em>{{ site.author-name }}</em></h1>
-  <p class="c-hero__lede">{{ site.about-author | strip_html }}</p>
+  {% if site.author-image %}
+  <span class="c-hero__portrait">
+    <img src="{{site.baseurl}}/images/{{site.author-image}}" alt="{{site.author-name}}">
+  </span>
+  {% endif %}
 
-  <div class="c-hero__meta">
-    {% if site.author-image %}
-    <span class="c-hero__avatar">
-      <img src="{{site.baseurl}}/images/{{site.author-image}}" alt="{{site.author-name}}">
-    </span>
-    {% endif %}
-    <div class="c-hero__meta-text">
-      <div class="c-hero__meta-name">{{ site.author-name }}</div>
-      <div class="c-hero__meta-role">{{ site.author-job }}</div>
-    </div>
+  <div class="c-hero__eyebrow">About</div>
+  <h1 class="c-hero__title">Hi, I'm <em>Winter Sun</em></h1>
+  <div class="c-hero__byline">
+    <span class="c-hero__byline-rule"></span>
+    <span class="c-hero__byline-text">冬璇 · {{ site.author-job }}</span>
+    <span class="c-hero__byline-rule"></span>
   </div>
+
+  <p class="c-hero__lede">
+    <span class="c-hero__quote">&ldquo;</span>
+    {{ site.about-author | strip_html }}
+    <span class="c-hero__quote c-hero__quote--end">&rdquo;</span>
+  </p>
 
   <div class="c-hero__socials">
     {% if site.author-email %}<a href="{{site.baseurl}}/contact/">Contact</a>{% endif %}

--- a/_sass/5-components/_header.scss
+++ b/_sass/5-components/_header.scss
@@ -31,15 +31,29 @@
   white-space: nowrap;
   display: inline-flex;
   align-items: baseline;
-  gap: 8px;
-  &:hover { color: $accent; }
+  gap: 0;
+  transition: $global-transition;
+  &:hover {
+    color: $accent;
+    .c-brand__mark { color: $accent; }
+  }
+  .c-brand__mark {
+    font-style: italic;
+    font-weight: 700;
+    color: $accent;
+    transition: $global-transition;
+  }
+  .c-brand__rest {
+    font-weight: 400;
+  }
   .c-brand__dot {
     display: inline-block;
-    width: 6px;
-    height: 6px;
+    width: 5px;
+    height: 5px;
     border-radius: 50%;
     background-color: $accent;
-    transform: translateY(-3px);
+    margin-left: 4px;
+    transform: translateY(-2px);
   }
 }
 

--- a/_sass/5-components/_hero.scss
+++ b/_sass/5-components/_hero.scss
@@ -3,18 +3,52 @@
 =============== */
 
 .c-hero {
-  padding: 96px 0 72px;
+  padding: 80px 0 72px;
   text-align: center;
 }
 
+/* ----- Round portrait at top ----- */
+.c-hero__portrait {
+  display: inline-block;
+  width: 96px;
+  height: 96px;
+  margin: 0 auto 28px;
+  border-radius: 50%;
+  overflow: hidden;
+  background-color: $line;
+  position: relative;
+  box-shadow:
+    0 0 0 1px $line-strong,
+    0 0 0 6px $paper,
+    0 0 0 7px $line,
+    0 18px 40px -16px rgba(31, 29, 26, 0.20);
+  transition: $global-transition;
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow:
+      0 0 0 1px $accent-soft,
+      0 0 0 6px $paper,
+      0 0 0 7px $line,
+      0 22px 44px -14px rgba(31, 29, 26, 0.26);
+  }
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+/* ----- Decorative eyebrow ----- */
 .c-hero__eyebrow {
   display: inline-block;
   font-family: $heading-font-family;
-  font-size: 12px;
-  letter-spacing: 0.32em;
+  font-style: italic;
+  font-size: 13px;
+  letter-spacing: 0.28em;
   text-transform: uppercase;
   color: $accent;
-  margin-bottom: 18px;
+  margin-bottom: 22px;
   &::before, &::after {
     content: "";
     display: inline-block;
@@ -22,19 +56,20 @@
     height: 1px;
     background-color: $accent;
     vertical-align: middle;
-    margin: 0 14px;
-    transform: translateY(-2px);
+    margin: 0 16px;
+    transform: translateY(-3px);
   }
 }
 
+/* ----- Big serif title ----- */
 .c-hero__title {
   font-family: $heading-font-family;
-  font-size: 64px;
-  line-height: 1.05;
+  font-size: 72px;
+  line-height: 1.02;
   font-weight: 700;
   color: $ink;
-  margin: 0 0 18px;
-  letter-spacing: -0.01em;
+  margin: 0 0 26px;
+  letter-spacing: -0.015em;
   em {
     font-style: italic;
     color: $accent;
@@ -42,62 +77,84 @@
   }
 }
 
-.c-hero__lede {
-  max-width: 620px;
-  margin: 0 auto 28px;
-  font-size: 17px;
-  line-height: 1.7;
-  color: $ink-soft;
-}
-
-.c-hero__meta {
+/* ----- Byline (name) with hairline rules ----- */
+.c-hero__byline {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 14px;
+  margin: 0 0 36px;
+}
+
+.c-hero__byline-rule {
+  flex: 0 1 60px;
+  height: 1px;
+  background-color: $line-strong;
+}
+
+.c-hero__byline-text {
   font-family: $heading-font-family;
-  font-size: 13px;
-  color: $muted;
+  font-style: italic;
+  font-size: 15px;
+  color: $ink-soft;
   letter-spacing: 0.04em;
-  .c-hero__avatar {
-    width: 44px;
-    height: 44px;
-    border-radius: 50%;
-    overflow: hidden;
-    background-color: $line;
-    img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      display: block;
-    }
-  }
-  .c-hero__meta-text {
-    text-align: left;
-    line-height: 1.3;
-  }
-  .c-hero__meta-name {
-    color: $ink;
-    font-weight: 700;
-    font-size: 14px;
-  }
-  .c-hero__meta-role {
-    font-size: 12px;
-    color: $muted;
+  white-space: nowrap;
+}
+
+/* ----- Lede (the tagline / quote) ----- */
+.c-hero__lede {
+  position: relative;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 0 32px;
+  font-family: $heading-font-family;
+  font-style: italic;
+  font-size: 22px;
+  line-height: 1.55;
+  color: $ink-soft;
+}
+
+.c-hero__quote {
+  font-family: 'Volkhov', Georgia, serif;
+  font-style: italic;
+  font-weight: 700;
+  font-size: 56px;
+  line-height: 0;
+  color: $accent-soft;
+  vertical-align: -0.32em;
+  margin-right: 6px;
+  user-select: none;
+  &--end {
+    margin-right: 0;
+    margin-left: 6px;
+    vertical-align: -0.55em;
   }
 }
 
+/* ----- Author role pill (homepage hero) ----- */
+.c-hero__role {
+  margin-top: 32px;
+  font-family: $heading-font-family;
+  font-style: italic;
+  font-size: 13px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: $muted;
+}
+
+/* ----- Socials (about page) ----- */
 .c-hero__socials {
-  margin-top: 22px;
+  margin-top: 36px;
   display: flex;
   justify-content: center;
   gap: 10px;
+  flex-wrap: wrap;
   a {
     display: inline-block;
-    padding: 6px 14px;
+    padding: 7px 16px;
     font-family: $heading-font-family;
     font-size: 12px;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.14em;
     text-transform: uppercase;
     color: $ink-soft;
     text-decoration: none;
@@ -112,15 +169,36 @@
   }
 }
 
+/* ----- Responsive ----- */
 @media only screen and (max-width: 720px) {
   .c-hero {
-    padding: 56px 0 40px;
+    padding: 48px 0 40px;
+  }
+  .c-hero__portrait {
+    width: 80px;
+    height: 80px;
+    margin-bottom: 22px;
   }
   .c-hero__title {
+    font-size: 44px;
+    margin-bottom: 20px;
+  }
+  .c-hero__byline {
+    gap: 10px;
+    margin-bottom: 26px;
+  }
+  .c-hero__byline-rule { flex-basis: 32px; }
+  .c-hero__byline-text { font-size: 13px; }
+  .c-hero__lede {
+    font-size: 17px;
+    padding: 0 8px;
+  }
+  .c-hero__quote {
     font-size: 40px;
   }
-  .c-hero__lede {
-    font-size: 15px;
+  .c-hero__eyebrow {
+    font-size: 11px;
+    &::before, &::after { width: 18px; margin: 0 10px; }
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -3,21 +3,27 @@ layout: home
 ---
 
 <section class="c-hero">
-  <div class="c-hero__eyebrow">Personal Journal</div>
-  <h1 class="c-hero__title">{{ site.title | replace: "'s Zone", "" }}<em>'s Zone</em></h1>
-  <p class="c-hero__lede">{{ site.about-author | strip_html }}</p>
+  {% if site.author-image %}
+  <a class="c-hero__portrait" href="{{site.baseurl}}/" aria-label="Home">
+    <img src="{{site.baseurl}}/images/{{site.author-image}}" alt="{{site.author-name}}">
+  </a>
+  {% endif %}
 
-  <div class="c-hero__meta">
-    {% if site.author-image %}
-    <a class="c-hero__avatar" href="{{site.baseurl}}/">
-      <img src="{{site.baseurl}}/images/{{site.author-image}}" alt="{{site.author-name}}">
-    </a>
-    {% endif %}
-    <div class="c-hero__meta-text">
-      <div class="c-hero__meta-name">{{ site.author-name }}</div>
-      <div class="c-hero__meta-role">{{ site.author-job }}</div>
-    </div>
+  <div class="c-hero__eyebrow">Notes from Wonderland</div>
+  <h1 class="c-hero__title">Winter in <em>Wonderland</em></h1>
+  <div class="c-hero__byline">
+    <span class="c-hero__byline-rule"></span>
+    <span class="c-hero__byline-text">by 冬璇 · Winter Sun</span>
+    <span class="c-hero__byline-rule"></span>
   </div>
+
+  <p class="c-hero__lede">
+    <span class="c-hero__quote">&ldquo;</span>
+    {{ site.about-author | strip_html }}
+    <span class="c-hero__quote c-hero__quote--end">&rdquo;</span>
+  </p>
+
+  <div class="c-hero__role">{{ site.author-job }}</div>
 </section>
 
 <div class="c-posts o-opacity">


### PR DESCRIPTION
## Summary

Rename the blog and rebuild the hero section to feel like a magazine cover.

**Naming**
- Site title: **Winter in Wonderland** (Alice-inspired)
- Byline under the title: **by 冬璇 · Winter Sun**
- Topbar brand mark: serif **W**inter + accent dot

**Hero redesign**
- 96px round portrait at the top with a layered double-ring frame
- Italic eyebrow "Notes from Wonderland" with hairline accents
- Big serif title with italic rose accent on the word "Wonderland"
- Byline flanked by hairline rules
- Lede now in Volkhov italic, wrapped in oversized rose quote marks (instead of the previous plain Open Sans)
- Author role rendered as small-caps below

**About page** adopts the same hero layout for consistency.

## Test plan
- [ ] Homepage shows portrait + new title + italic lede with quote marks
- [ ] Topbar brand reads "Winter·" with W in italic accent color
- [ ] Byline shows "by 冬璇 · Winter Sun" with hairline rules on both sides
- [ ] About page hero matches the homepage style (with social pills)
- [ ] Mobile (≤720px): portrait shrinks to 80px, title scales down

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_