### PR TITLE
Fix hero portrait centering and inline quote layout

### DIFF
--- a/_sass/5-components/_hero.scss
+++ b/_sass/5-components/_hero.scss
@@ -9,7 +9,7 @@
 
 /* ----- Round portrait at top ----- */
 .c-hero__portrait {
-  display: inline-block;
+  display: block;
   width: 96px;
   height: 96px;
   margin: 0 auto 28px;
@@ -106,7 +106,7 @@
   position: relative;
   max-width: 640px;
   margin: 0 auto;
-  padding: 0 32px;
+  padding: 0 16px;
   font-family: $heading-font-family;
   font-style: italic;
   font-size: 22px;
@@ -115,20 +115,15 @@
 }
 
 .c-hero__quote {
+  display: inline;
   font-family: 'Volkhov', Georgia, serif;
   font-style: italic;
   font-weight: 700;
-  font-size: 56px;
-  line-height: 0;
+  font-size: 1.7em;
   color: $accent-soft;
-  vertical-align: -0.32em;
-  margin-right: 6px;
+  vertical-align: -0.18em;
   user-select: none;
-  &--end {
-    margin-right: 0;
-    margin-left: 6px;
-    vertical-align: -0.55em;
-  }
+  margin: 0 0.12em;
 }
 
 /* ----- Author role pill (homepage hero) ----- */


### PR DESCRIPTION
## Summary

Two desktop layout bugs reported in the new hero:

1. **Portrait off-center on wide viewports** — it was `display: inline-block` relying on `text-align: center`, which mis-positions on certain widths. Switched to `display: block` + `margin: 0 auto`.

2. **Closing quote dropped to its own line** — the lede quotes used `line-height: 0` with `vertical-align: -0.55em` on a 56px font; that combination pushed the closing quote onto a new line in some inline layouts. Replaced with a 1.7em glyph and a small baseline shift, so both quotes stay inline with the tagline.

Verified at 720 / 1280 / 1440px viewports — portrait centers, quotes hug the text on the same line.

## Test plan
- [ ] Open homepage on desktop — portrait sits exactly above the title centerline
- [ ] Lede shows `" You found me. Why'd you have to wait to find me? "` all on one line
- [ ] About page hero matches

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_