### PR TITLE
Make topbar nav work consistently from /sam/, /about/, and posts

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,18 +4,40 @@
       <span class="c-brand__mark">W</span><span class="c-brand__rest">inter</span><span class="c-brand__dot"></span>
     </a>
 
+    {% comment %} Determine active tab from page URL {% endcomment %}
+    {% assign nav_active = '' %}
+    {% if page.url contains '/sam' %}{% assign nav_active = 'sam' %}
+    {% elsif page.url == '/about/' %}{% assign nav_active = 'about' %}
+    {% elsif page.url == '/' or page.url == '/index.html' %}{% assign nav_active = 'all' %}
+    {% endif %}
+
     <nav class="c-nav" aria-label="Primary">
       <ul class="c-nav__list u-lists-reset">
-        <li class="c-nav__item c-item_post is-active" data-filter="all">All</li>
-        <li class="c-nav__item c-item_post" data-filter="Daily">Daily</li>
-        <li class="c-nav__item c-item_post" data-filter="Novel">Novel</li>
-        <li class="c-nav__item c-item_post" data-filter="AU Story">AU Story</li>
-        <li class="c-nav__item c-item_post" data-filter="Lyrics">Lyrics</li>
-        <li class="c-nav__item c-item_images">Gallery</li>
-        <li class="c-nav__item c-nav__item--link">
+        <li class="c-nav__item c-item_post{% if nav_active == 'all' %} is-active{% endif %}" data-filter="all">
+          <a href="{{site.baseurl}}/">All</a>
+        </li>
+        <li class="c-nav__item c-item_post" data-filter="Daily">
+          <a href="{{site.baseurl}}/?cat=Daily">Daily</a>
+        </li>
+        <li class="c-nav__item c-item_post" data-filter="Novel">
+          <a href="{{site.baseurl}}/?cat=Novel">Novel</a>
+        </li>
+        <li class="c-nav__item c-item_post" data-filter="AU Story">
+          <a href="{{site.baseurl}}/?cat=AU+Story">AU Story</a>
+        </li>
+        <li class="c-nav__item c-item_post" data-filter="Lyrics">
+          <a href="{{site.baseurl}}/?cat=Lyrics">Lyrics</a>
+        </li>
+        <li class="c-nav__item c-item_images">
+          <a href="{{site.baseurl}}/?view=gallery">Gallery</a>
+        </li>
+        <li class="c-nav__item c-item_tags">
+          <a href="{{site.baseurl}}/?view=tags">Tags</a>
+        </li>
+        <li class="c-nav__item c-nav__item--link{% if nav_active == 'sam' %} is-active{% endif %}">
           <a href="{{site.baseurl}}/sam/">Sam</a>
         </li>
-        <li class="c-nav__item c-nav__item--link">
+        <li class="c-nav__item c-nav__item--link{% if nav_active == 'about' %} is-active{% endif %}">
           <a href="{{site.baseurl}}/about/">About</a>
         </li>
       </ul>

--- a/_sass/5-components/_header.scss
+++ b/_sass/5-components/_header.scss
@@ -81,11 +81,18 @@
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: $ink-soft;
-  cursor: pointer;
   border-radius: 999px;
   transition: $global-transition;
   user-select: none;
-  padding: 8px 14px;
+  padding: 0;
+  > a {
+    display: block;
+    padding: 8px 14px;
+    color: inherit;
+    text-decoration: none;
+    border-radius: 999px;
+    transition: $global-transition;
+  }
   &:hover {
     color: $accent;
     background-color: rgba(184, 92, 92, 0.06);
@@ -93,25 +100,7 @@
   &.is-active {
     color: $paper;
     background-color: $ink;
-  }
-  &.c-nav__item--link {
-    padding: 0;
-    background: transparent;
-    > a {
-      display: block;
-      padding: 8px 14px;
-      color: inherit;
-      text-decoration: none;
-      border-radius: 999px;
-      transition: $global-transition;
-    }
-    &:hover {
-      background: transparent;
-      > a {
-        color: $accent;
-        background-color: rgba(184, 92, 92, 0.06);
-      }
-    }
+    > a { color: inherit; }
   }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -26,7 +26,18 @@ $(document).ready(function () {
 
   /* =======================================
   // Top nav: switch view + filter by category
+  // - Each chip is a real link with a URL param
+  // - On the homepage, intercept clicks and filter in place
+  // - On other pages, let the link navigate to the homepage
   ======================================= */
+
+  var BASEURL = window.SITE_BASEURL || '';
+  // The homepage is at "{baseurl}/" or "{baseurl}/index.html"
+  function isHomepage() {
+    var p = window.location.pathname.replace(/\/index\.html$/, '/');
+    var home = (BASEURL + '/').replace(/\/+$/, '/');
+    return p === home || p === home.replace(/\/$/, '');
+  }
 
   function showPostsView() {
     $('.c-posts').show().addClass('o-opacity');
@@ -47,38 +58,79 @@ $(document).ready(function () {
     });
     var isEmpty = visible === 0 && filter !== 'all';
     $('[data-empty]').toggle(isEmpty);
-    // Hide the "More Stories" header when filtered set is empty or only featured remains
     var gridVisible = $('.c-post-grid .c-post:not(.is-hidden)').length;
     $('.c-section-heading').toggle(gridVisible > 0);
   }
 
-  $('.c-nav__list > .c-nav__item').on('click', function (e) {
-    var $this = $(this);
-    // Real-link items navigate natively
-    if ($this.hasClass('c-nav__item--link')) return;
+  function showGallery() {
+    $('.c-show-images').show().addClass('o-opacity');
+    $('.c-posts, .c-categories, .c-blog-tags').hide().removeClass('o-opacity');
+  }
 
+  function showTags() {
+    $('.c-blog-tags').show().addClass('o-opacity');
+    $('.c-posts, .c-categories, .c-show-images').hide().removeClass('o-opacity');
+  }
+
+  function setActiveNav($item) {
     $('.c-nav__list > .c-nav__item').removeClass('is-active');
-    $this.addClass('is-active');
+    $item.addClass('is-active');
+  }
+
+  // On homepage: intercept filter / view clicks
+  $('.c-nav__list > .c-nav__item').on('click', function (e) {
+    if (!isHomepage()) return; // let the link navigate
+    if ($(this).hasClass('c-nav__item--link')) return; // Sam / About always navigate
+
+    e.preventDefault();
+    var $this = $(this);
+    setActiveNav($this);
 
     if ($this.hasClass('c-item_post')) {
+      var filter = $this.attr('data-filter') || 'all';
       showPostsView();
-      applyCategoryFilter($this.attr('data-filter') || 'all');
-    } else if ($this.hasClass('c-item_category')) {
-      $('.c-categories').show().addClass('o-opacity');
-      $('.c-posts, .c-blog-tags, .c-show-images').hide().removeClass('o-opacity');
-    } else if ($this.hasClass('c-item_tags')) {
-      $('.c-blog-tags').show().addClass('o-opacity');
-      $('.c-posts, .c-categories, .c-show-images').hide().removeClass('o-opacity');
+      applyCategoryFilter(filter);
+      var nextUrl = filter === 'all' ? (BASEURL + '/') : (BASEURL + '/?cat=' + encodeURIComponent(filter));
+      if (window.history && window.history.replaceState) {
+        window.history.replaceState(null, '', nextUrl);
+      }
     } else if ($this.hasClass('c-item_images')) {
-      $('.c-show-images').show().addClass('o-opacity');
-      $('.c-posts, .c-categories, .c-blog-tags').hide().removeClass('o-opacity');
+      showGallery();
+      if (window.history && window.history.replaceState) {
+        window.history.replaceState(null, '', BASEURL + '/?view=gallery');
+      }
+    } else if ($this.hasClass('c-item_tags')) {
+      showTags();
+      if (window.history && window.history.replaceState) {
+        window.history.replaceState(null, '', BASEURL + '/?view=tags');
+      }
     }
 
-    // Scroll up so user sees the change
     if ($('main.c-content').length && window.scrollY > 200) {
       $('html, body').animate({ scrollTop: $('main.c-content').offset().top - 80 }, 250);
     }
   });
+
+  // On homepage load: read URL params and apply filter / view
+  if (isHomepage()) {
+    var params = new URLSearchParams(window.location.search);
+    var cat = params.get('cat');
+    var view = params.get('view');
+    if (cat) {
+      var $catItem = $('.c-nav__list > .c-item_post[data-filter="' + cat.replace(/"/g, '\\"') + '"]');
+      if ($catItem.length) {
+        setActiveNav($catItem);
+        showPostsView();
+        applyCategoryFilter(cat);
+      }
+    } else if (view === 'gallery') {
+      setActiveNav($('.c-nav__list > .c-item_images'));
+      showGallery();
+    } else if (view === 'tags') {
+      setActiveNav($('.c-nav__list > .c-item_tags'));
+      showTags();
+    }
+  }
 
   /* =======================
   // Adding ajax pagination


### PR DESCRIPTION
## Summary

On `/sam/`, `/about/`, and post pages, the topbar was broken in two ways:

1. **Active tab always showed "All"** — `is-active` was hard-coded in the markup.
2. **Filter chips did nothing** — Daily / Novel / Gallery / Tags etc. tried to filter post cards in place, but those pages don't have any post cards, so clicks looked like they were ignored.

## Fix

- Every chip is now a real `<a>`. Filter chips link to `/`, `/?cat=Daily`, `/?view=gallery`, etc. so clicking from any page lands on the homepage with the right state already applied.
- Liquid sets `is-active` from `page.url`: `/sam*` → Sam, `/about/` → About, `/` → All.
- On the homepage, JS reads `?cat=` / `?view=` from the URL on load and applies the matching filter / view, then mirrors clicks back into the URL via `history.replaceState` so refreshes preserve state.
- Click handler still intercepts and filters in place on the homepage; on other pages it falls through to native navigation.
- Topbar markup unified — every `<li class="c-nav__item">` now wraps an `<a>`, and the styling moved onto the inner `<a>`.

Verified: from `/sam/`, click DAILY → page navigates to `/?cat=Daily` and "Daily" is highlighted. Same flow works from `/about/`.

## Test plan
- [ ] Open `/sam/` — only "Sam" is highlighted
- [ ] Open `/about/` — only "About" is highlighted
- [ ] On `/sam/`, click "Daily" → lands on `/?cat=Daily`, only "Daily" highlighted, only Daily posts visible
- [ ] On `/?cat=Novel`, click "All" → URL becomes `/`, all posts visible, "All" highlighted
- [ ] On `/`, refresh while on `?cat=Lyrics` — filter persists

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_