### PR TITLE
Footer cleanup + NewYear in Gallery + Sam page polish

### DIFF
--- a/_includes/image-show.html
+++ b/_includes/image-show.html
@@ -1,6 +1,21 @@
 <div class="c-show-images" style="display: none;">
+
+  {% if site.social-newyear %}
+  <a class="c-feature-card" href="{{site.baseurl}}/{{site.social-newyear}}/" target="_blank" rel="noopener">
+    <div class="c-feature-card__eyebrow">
+      <span>Special · Interactive</span>
+      <span class="c-feature-card__tab">↗</span>
+    </div>
+    <h3 class="c-feature-card__title">跨年烟花 <em>New Year Fireworks</em></h3>
+    <p class="c-feature-card__desc">
+      一个小小的跨年网页——点开屏幕，烟花就会从这里开始绽放。
+    </p>
+    <span class="c-feature-card__cta">Open in new tab →</span>
+  </a>
+  {% endif %}
+
   <div class="c-section-heading">
-    <h3 class="c-section-heading__title">Gallery</h3>
+    <h3 class="c-section-heading__title">Illustrations</h3>
     <span class="c-section-heading__meta">{{ site.gallery_images.size }} pieces</span>
   </div>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -12,9 +12,6 @@ layout: default
 <footer class="c-footer">
   <div class="o-container">
     <div class="c-footer__links">
-      {% if site.social-chatgpt %}<a href="{{site.baseurl}}/{{site.social-chatgpt}}/" rel="noopener">ChatGPT</a>{% endif %}
-      {% if site.social-newyear %}<a href="{{site.baseurl}}/{{site.social-newyear}}/" rel="noopener">NewYear</a>{% endif %}
-      {% if site.social-sam %}<a href="{{site.baseurl}}/{{site.social-sam}}/" rel="noopener">Sam</a>{% endif %}
       {% if site.author-weibo %}<a href="{{site.author-weibo}}" target="_blank" rel="noopener">Weibo</a>{% endif %}
       {% if site.author-bilibili %}<a href="{{site.author-bilibili}}" target="_blank" rel="noopener">Bilibili</a>{% endif %}
       {% if site.author-email %}<a href="{{site.baseurl}}/contact/">Email</a>{% endif %}

--- a/_sass/5-components/_index-post.scss
+++ b/_sass/5-components/_index-post.scss
@@ -218,6 +218,99 @@
 .c-post.is-hidden,
 .c-featured.is-hidden { display: none; }
 
+/* ----- Feature card (e.g. New Year fireworks above the image grid) ----- */
+.c-feature-card {
+  display: block;
+  position: relative;
+  padding: 28px 30px;
+  margin-bottom: 32px;
+  background:
+    radial-gradient(circle at 88% 28%, rgba(184, 92, 92, 0.10), transparent 40%),
+    radial-gradient(circle at 12% 78%, rgba(212, 196, 176, 0.18), transparent 38%),
+    $paper;
+  border: 1px solid $line;
+  border-radius: 4px;
+  text-decoration: none;
+  color: inherit;
+  overflow: hidden;
+  transition: $global-transition;
+  &::before {
+    content: "✦";
+    position: absolute;
+    top: 18px;
+    right: 22px;
+    color: $accent-soft;
+    font-size: 14px;
+    opacity: 0.6;
+  }
+  &:hover {
+    transform: translateY(-3px);
+    border-color: $accent-soft;
+    box-shadow: 0 22px 44px -22px rgba(31, 29, 26, 0.22);
+    .c-feature-card__title { color: $accent; }
+    .c-feature-card__cta { color: $accent; }
+    .c-feature-card__tab { transform: translate(2px, -2px); }
+  }
+}
+
+.c-feature-card__eyebrow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: $heading-font-family;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: $accent;
+  margin-bottom: 12px;
+  padding-right: 18px;
+}
+
+.c-feature-card__tab {
+  display: inline-block;
+  font-size: 14px;
+  letter-spacing: 0;
+  color: $muted;
+  transition: $global-transition;
+}
+
+.c-feature-card__title {
+  font-family: $heading-font-family;
+  font-size: 26px;
+  line-height: 1.2;
+  font-weight: 700;
+  color: $ink;
+  margin: 0 0 10px;
+  letter-spacing: -0.005em;
+  transition: color $global-transition;
+  em {
+    font-style: italic;
+    color: $accent;
+    font-weight: 400;
+  }
+}
+
+.c-feature-card__desc {
+  font-size: 15px;
+  line-height: 1.7;
+  color: $ink-soft;
+  margin: 0 0 14px;
+}
+
+.c-feature-card__cta {
+  font-family: $heading-font-family;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: $ink-soft;
+  transition: color $global-transition;
+}
+
+@media only screen and (max-width: 720px) {
+  .c-feature-card { padding: 22px; }
+  .c-feature-card__title { font-size: 21px; }
+}
+
 /* ----- Gallery (image grid) ----- */
 .c-gallery {
   display: grid;


### PR DESCRIPTION
## Summary

Three small follow-ups bundled together:

**1. Footer trimmed to contact-only**
The ChatGPT / NewYear / Sam shortcuts duplicated topbar navigation. Footer now keeps only **Weibo · Bilibili · Email**.

**2. NewYear moved into Gallery as a feature card**
- Card eyebrow: **Special · Interactive**
- Title: 跨年烟花 *New Year Fireworks*
- Soft warm radial gradient + ✦ sparkle to hint at fireworks
- Opens `/newyear/` in a new tab
- The image grid keeps its place underneath, now labelled **Illustrations**

**3. Sam page polish**
- Lede max-width bumped 640 → 800px (with `text-wrap: pretty`) so the longer Sam quote keeps both quote marks on the same line.
- Dropped two films Sam Rockwell isn't actually in (《在云端》《左转灾难》) and replaced with 《乔乔的异想世界》.
- Rewrote the work-ethic bullet: he has appeared in plenty of so-called bad films, but he doesn't act for fame — he just loves it, and gives every role full attention regardless of how the film does.

## Test plan
- [ ] Footer on every page shows only Weibo / Bilibili / Email + copyright
- [ ] Click Gallery → NewYear card sits above the illustrations; clicking it opens `/newyear/` in a new tab
- [ ] Click an illustration → existing lightbox still works
- [ ] Open `/sam/` — both quotes hug the same line as the tagline
- [ ] Sam intro reads correctly (no 在云端 / 左转灾难; new work-ethic line)

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY