### PR TITLE
Add Red Book contact link and Sam "Ongoing" section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ author-job:     Translator / Romantic / Dreamer
 author-email:   winterzhangyixuan@qq.com # Add your email for contant form.
 author-weibo:   https://weibo.com/wintersunzhang
 author-bilibili:   https://space.bilibili.com/185894171
+author-redbook: https://www.xiaohongshu.com/user/profile/5cb52bc3000000001200caab?xsec_token=YBDAjPaqx6wqyz2-Im0YSlwFtPkWgBp8nkMX0rfyntfEo=&xsec_source=app_share&xhsshare=CopyLink&shareRedId=N0lENTVHRzw2NzUyOTgwNjc1OTdHRkdL&apptime=1777654818&share_id=fcdbd7106d0a46cba87e52375304c1d5
 about-author:   You found me. Why'd you have to wait to find me?
 
 # Social settings

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -14,6 +14,7 @@ layout: default
     <div class="c-footer__links">
       {% if site.author-weibo %}<a href="{{site.author-weibo}}" target="_blank" rel="noopener">Weibo</a>{% endif %}
       {% if site.author-bilibili %}<a href="{{site.author-bilibili}}" target="_blank" rel="noopener">Bilibili</a>{% endif %}
+      {% if site.author-redbook %}<a href="{{site.author-redbook}}" target="_blank" rel="noopener">Red Book</a>{% endif %}
       {% if site.author-email %}<a href="{{site.baseurl}}/contact/">Email</a>{% endif %}
     </div>
     <div class="c-footer__copy">

--- a/_pages/about/index.html
+++ b/_pages/about/index.html
@@ -29,6 +29,7 @@ permalink: /about/
     {% if site.author-email %}<a href="{{site.baseurl}}/contact/">Contact</a>{% endif %}
     {% if site.author-weibo %}<a href="{{site.author-weibo}}" target="_blank" rel="noopener">Weibo</a>{% endif %}
     {% if site.author-bilibili %}<a href="{{site.author-bilibili}}" target="_blank" rel="noopener">Bilibili</a>{% endif %}
+    {% if site.author-redbook %}<a href="{{site.author-redbook}}" target="_blank" rel="noopener">Red Book</a>{% endif %}
   </div>
 </section>
 

--- a/sam/index.html
+++ b/sam/index.html
@@ -58,6 +58,17 @@ title: Sam
     而 2026 年的春天，我终于明白——<br>
     那个最特别的人，原来一直都是他。
   </p>
+
+  <h2 class="c-sam-intro__heading">Ongoing</h2>
+
+  <p>
+    自 2026 年 2 月 13 日——情人节的前一天——起，我开始在小红书每日更新一点和他相关的东西。或一张照片，或一段影视切片，或一段访谈……我从没对任何事如此坚持过，但对他，我一天都没落下。
+  </p>
+
+  <p class="c-sam-intro__closing">
+    我很期待 2027 年的同一天——日更满一周年的那天——<br>
+    我还在继续更新。
+  </p>
 </article>
 
 <section class="c-sam-collection">


### PR DESCRIPTION
## Summary

**1. Add Red Book (小红书) as a contact link**
Stored under `site.author-redbook` in `_config.yml`. Shown alongside Weibo / Bilibili in the site footer and on the About page hero socials.

**2. Add a third "Ongoing" section to the Sam page**
A quiet coda after the "Our Story" climax, describing the daily updates on Red Book:

> 自 2026 年 2 月 13 日——情人节的前一天——起，我开始在小红书每日更新一点和他相关的东西。或一张照片，或一段影视切片，或一段访谈……我从没对任何事如此坚持过，但对他，我一天都没落下。
>
> 我很期待 2027 年的同一天——日更满一周年的那天——
> 我还在继续更新。

## Test plan
- [ ] Footer shows: Weibo · Bilibili · Red Book · Email
- [ ] About page hero shows the Red Book pill alongside Weibo / Bilibili / Contact
- [ ] Clicking Red Book opens your profile in a new tab
- [ ] Sam page now ends with the new "Ongoing" subsection

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_