### PR TITLE
Add per-tab mini-hero so switching feels like a new view

### DIFF
--- a/_sass/5-components/_hero.scss
+++ b/_sass/5-components/_hero.scss
@@ -7,6 +7,36 @@
   text-align: center;
 }
 
+/* Only show the hero matching the active filter / view */
+[data-hero-id] { display: none; }
+:root:not([data-hero-active]) [data-hero-id="all"] { display: block; }
+:root[data-hero-active="all"] [data-hero-id="all"] { display: block; }
+:root[data-hero-active="Daily"] [data-hero-id="Daily"] { display: block; }
+:root[data-hero-active="Novel"] [data-hero-id="Novel"] { display: block; }
+:root[data-hero-active="AU Story"] [data-hero-id="AU Story"] { display: block; }
+:root[data-hero-active="Lyrics"] [data-hero-id="Lyrics"] { display: block; }
+:root[data-hero-active="gallery"] [data-hero-id="gallery"] { display: block; }
+:root[data-hero-active="tags"] [data-hero-id="tags"] { display: block; }
+
+/* Compact filter hero — eyebrow + title + byline only */
+.c-hero--filter {
+  padding: 64px 0 48px;
+  .c-hero__title {
+    font-size: 56px;
+    margin-bottom: 22px;
+  }
+  .c-hero__byline {
+    margin-bottom: 0;
+  }
+}
+
+@media only screen and (max-width: 720px) {
+  .c-hero--filter {
+    padding: 44px 0 32px;
+    .c-hero__title { font-size: 36px; }
+  }
+}
+
 /* ----- Round portrait at top ----- */
 .c-hero__portrait {
   display: block;

--- a/index.html
+++ b/index.html
@@ -2,7 +2,20 @@
 layout: home
 ---
 
-<section class="c-hero">
+<script>
+(function () {
+  try {
+    var p = new URLSearchParams(window.location.search);
+    var active = 'all';
+    if (p.get('cat')) active = p.get('cat');
+    else if (p.get('view') === 'gallery') active = 'gallery';
+    else if (p.get('view') === 'tags') active = 'tags';
+    document.documentElement.setAttribute('data-hero-active', active);
+  } catch (e) { /* fall back to default */ }
+})();
+</script>
+
+<section class="c-hero" data-hero-id="all">
   {% if site.author-image %}
   <a class="c-hero__portrait" href="{{site.baseurl}}/" aria-label="Home">
     <img src="{{site.baseurl}}/images/{{site.author-image}}" alt="{{site.author-name}}">
@@ -24,6 +37,66 @@ layout: home
   </p>
 
   <div class="c-hero__role">{{ site.author-job }}</div>
+</section>
+
+<section class="c-hero c-hero--filter" data-hero-id="Daily">
+  <div class="c-hero__eyebrow">Daily</div>
+  <h1 class="c-hero__title">日常 <em>Daily</em></h1>
+  <div class="c-hero__byline">
+    <span class="c-hero__byline-rule"></span>
+    <span class="c-hero__byline-text">平凡日子里的感想、心情，和那些值得停留的片刻</span>
+    <span class="c-hero__byline-rule"></span>
+  </div>
+</section>
+
+<section class="c-hero c-hero--filter" data-hero-id="Novel">
+  <div class="c-hero__eyebrow">Novel</div>
+  <h1 class="c-hero__title">小说 <em>Stories</em></h1>
+  <div class="c-hero__byline">
+    <span class="c-hero__byline-rule"></span>
+    <span class="c-hero__byline-text">我写过的故事——关于爱、错过、和重逢</span>
+    <span class="c-hero__byline-rule"></span>
+  </div>
+</section>
+
+<section class="c-hero c-hero--filter" data-hero-id="AU Story">
+  <div class="c-hero__eyebrow">AU Story</div>
+  <h1 class="c-hero__title">幻想 <em>Alternate Universe</em></h1>
+  <div class="c-hero__byline">
+    <span class="c-hero__byline-rule"></span>
+    <span class="c-hero__byline-text">在另一个时空里，他们也曾相遇</span>
+    <span class="c-hero__byline-rule"></span>
+  </div>
+</section>
+
+<section class="c-hero c-hero--filter" data-hero-id="Lyrics">
+  <div class="c-hero__eyebrow">Lyrics</div>
+  <h1 class="c-hero__title">歌词 <em>Lyrics</em></h1>
+  <div class="c-hero__byline">
+    <span class="c-hero__byline-rule"></span>
+    <span class="c-hero__byline-text">译过的词，每一句都是来不及说出口的话</span>
+    <span class="c-hero__byline-rule"></span>
+  </div>
+</section>
+
+<section class="c-hero c-hero--filter" data-hero-id="gallery">
+  <div class="c-hero__eyebrow">Gallery</div>
+  <h1 class="c-hero__title">图集 <em>Pictures</em></h1>
+  <div class="c-hero__byline">
+    <span class="c-hero__byline-rule"></span>
+    <span class="c-hero__byline-text">画过的，看见过的，让人停留的画面</span>
+    <span class="c-hero__byline-rule"></span>
+  </div>
+</section>
+
+<section class="c-hero c-hero--filter" data-hero-id="tags">
+  <div class="c-hero__eyebrow">Tags</div>
+  <h1 class="c-hero__title">标签 <em>Tags</em></h1>
+  <div class="c-hero__byline">
+    <span class="c-hero__byline-rule"></span>
+    <span class="c-hero__byline-text">按主题与情绪，重新走一遍这里的每一篇</span>
+    <span class="c-hero__byline-rule"></span>
+  </div>
 </section>
 
 <div class="c-posts o-opacity">

--- a/js/main.js
+++ b/js/main.js
@@ -77,6 +77,10 @@ $(document).ready(function () {
     $item.addClass('is-active');
   }
 
+  function setActiveHero(name) {
+    document.documentElement.setAttribute('data-hero-active', name);
+  }
+
   // On homepage: intercept filter / view clicks
   $('.c-nav__list > .c-nav__item').on('click', function (e) {
     if (!isHomepage()) return; // let the link navigate
@@ -90,17 +94,20 @@ $(document).ready(function () {
       var filter = $this.attr('data-filter') || 'all';
       showPostsView();
       applyCategoryFilter(filter);
+      setActiveHero(filter);
       var nextUrl = filter === 'all' ? (BASEURL + '/') : (BASEURL + '/?cat=' + encodeURIComponent(filter));
       if (window.history && window.history.replaceState) {
         window.history.replaceState(null, '', nextUrl);
       }
     } else if ($this.hasClass('c-item_images')) {
       showGallery();
+      setActiveHero('gallery');
       if (window.history && window.history.replaceState) {
         window.history.replaceState(null, '', BASEURL + '/?view=gallery');
       }
     } else if ($this.hasClass('c-item_tags')) {
       showTags();
+      setActiveHero('tags');
       if (window.history && window.history.replaceState) {
         window.history.replaceState(null, '', BASEURL + '/?view=tags');
       }


### PR DESCRIPTION
## Summary

Each filter / view tab now has its own compact hero — a smaller version of the Sam / About pattern (eyebrow + bilingual title + one-line tagline between hairline rules), so switching tabs feels like landing on a new view. Half the height of the main "Winter in Wonderland" hero, no portrait, no quote.

**Taglines**
- **Daily** — 平凡日子里的感想、心情，和那些值得停留的片刻
- **Novel** — 我写过的故事——关于爱、错过、和重逢
- **AU Story** — 在另一个时空里，他们也曾相遇
- **Lyrics** — 译过的词，每一句都是来不及说出口的话
- **Gallery** — 画过的，看见过的，让人停留的画面
- **Tags** — 按主题与情绪，重新走一遍这里的每一篇

**How it works**
- All hero variants live in `index.html` under `[data-hero-id="..."]`.
- An inline script reads `?cat=` / `?view=` and sets `[data-hero-active]` on `<html>` before paint, so a direct URL hit lands on the correct hero with no flash.
- CSS shows only the matching hero; the default falls back to "all".
- The in-page filter click handler now also calls `setActiveHero()` so swapping tabs without a reload swaps the hero too.

## Test plan
- [ ] Click each top-bar tab — title and tagline change, post grid below updates accordingly
- [ ] Visit `/?cat=Lyrics` directly — Lyrics hero shows immediately, no flash of "Winter in Wonderland"
- [ ] Click "All" — original full Winter in Wonderland hero returns
- [ ] AU Story still shows the empty state below the hero (no posts)

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_