### PR TITLE
Make per-tab heroes feel like Sam / About

### DIFF
--- a/_sass/5-components/_hero.scss
+++ b/_sass/5-components/_hero.scss
@@ -18,22 +18,27 @@
 :root[data-hero-active="gallery"] [data-hero-id="gallery"] { display: block; }
 :root[data-hero-active="tags"] [data-hero-id="tags"] { display: block; }
 
-/* Compact filter hero — eyebrow + title + byline only */
+/* Compact filter hero — eyebrow + title + byline only.
+   Same typographic style as Sam/About, just no portrait/quote. */
 .c-hero--filter {
-  padding: 64px 0 48px;
+  padding: 72px 0 56px;
   .c-hero__title {
-    font-size: 56px;
-    margin-bottom: 22px;
+    font-size: 68px;
+    margin-bottom: 30px;
   }
   .c-hero__byline {
     margin-bottom: 0;
+  }
+  .c-hero__byline-text {
+    font-size: 16px;
   }
 }
 
 @media only screen and (max-width: 720px) {
   .c-hero--filter {
-    padding: 44px 0 32px;
-    .c-hero__title { font-size: 36px; }
+    padding: 48px 0 36px;
+    .c-hero__title { font-size: 40px; margin-bottom: 22px; }
+    .c-hero__byline-text { font-size: 13px; }
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ layout: home
 
 <section class="c-hero c-hero--filter" data-hero-id="Daily">
   <div class="c-hero__eyebrow">Daily</div>
-  <h1 class="c-hero__title">日常 <em>Daily</em></h1>
+  <h1 class="c-hero__title">Slow <em>Days</em></h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
     <span class="c-hero__byline-text">平凡日子里的感想、心情，和那些值得停留的片刻</span>
@@ -51,7 +51,7 @@ layout: home
 
 <section class="c-hero c-hero--filter" data-hero-id="Novel">
   <div class="c-hero__eyebrow">Novel</div>
-  <h1 class="c-hero__title">小说 <em>Stories</em></h1>
+  <h1 class="c-hero__title">These <em>Stories</em></h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
     <span class="c-hero__byline-text">我写过的故事——关于爱、错过、和重逢</span>
@@ -61,7 +61,7 @@ layout: home
 
 <section class="c-hero c-hero--filter" data-hero-id="AU Story">
   <div class="c-hero__eyebrow">AU Story</div>
-  <h1 class="c-hero__title">幻想 <em>Alternate Universe</em></h1>
+  <h1 class="c-hero__title">If, <em>Otherwise</em></h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
     <span class="c-hero__byline-text">在另一个时空里，他们也曾相遇</span>
@@ -71,7 +71,7 @@ layout: home
 
 <section class="c-hero c-hero--filter" data-hero-id="Lyrics">
   <div class="c-hero__eyebrow">Lyrics</div>
-  <h1 class="c-hero__title">歌词 <em>Lyrics</em></h1>
+  <h1 class="c-hero__title">Borrowed <em>Songs</em></h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
     <span class="c-hero__byline-text">译过的词，每一句都是来不及说出口的话</span>
@@ -81,7 +81,7 @@ layout: home
 
 <section class="c-hero c-hero--filter" data-hero-id="gallery">
   <div class="c-hero__eyebrow">Gallery</div>
-  <h1 class="c-hero__title">图集 <em>Pictures</em></h1>
+  <h1 class="c-hero__title">Pictures <em>Kept</em></h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
     <span class="c-hero__byline-text">画过的，看见过的，让人停留的画面</span>
@@ -91,7 +91,7 @@ layout: home
 
 <section class="c-hero c-hero--filter" data-hero-id="tags">
   <div class="c-hero__eyebrow">Tags</div>
-  <h1 class="c-hero__title">标签 <em>Tags</em></h1>
+  <h1 class="c-hero__title">By <em>Mood</em></h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
     <span class="c-hero__byline-text">按主题与情绪，重新走一遍这里的每一篇</span>


### PR DESCRIPTION
## Summary

Replace the bilingual "标签 Tags" style of the per-tab heroes with short poetic English titles in the Sam / About voice (regular text + italic-rose accent). The Chinese descriptions stay below as the byline between hairline rules.

- **Daily** — Slow *Days*
- **Novel** — These *Stories*
- **AU Story** — If, *Otherwise*
- **Lyrics** — Borrowed *Songs*
- **Gallery** — Pictures *Kept*
- **Tags** — By *Mood*

Also bumped filter title size from 56 → 68px so the typography sits in the same family as Sam (72px) and About (72px) instead of feeling like a smaller, demoted variant.

## Test plan
- [ ] Click each top-bar tab — title reads as a poetic phrase, italic accent on the noun
- [ ] Chinese description sits below the title between hairline rules
- [ ] Mobile (≤720px): title scales to 40px

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_