### PR TITLE
Homepage refresh: emoji brand, blog eyebrow, Home tab

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,8 @@
 <header class="c-topbar">
   <div class="o-container c-topbar__inner">
-    <a class="c-brand" href="{{site.baseurl}}/">
-      <span class="c-brand__mark">W</span><span class="c-brand__rest">inter</span><span class="c-brand__dot"></span>
+    <a class="c-brand" href="{{site.baseurl}}/" aria-label="Home">
+      <span class="c-brand__emoji" aria-hidden="true">❄️☀️</span>
+      <span class="c-brand__text u-screen-reader-text">Winter Sun</span>
     </a>
 
     {% comment %} Determine active tab from page URL {% endcomment %}
@@ -14,7 +15,7 @@
     <nav class="c-nav" aria-label="Primary">
       <ul class="c-nav__list u-lists-reset">
         <li class="c-nav__item c-item_post{% if nav_active == 'all' %} is-active{% endif %}" data-filter="all">
-          <a href="{{site.baseurl}}/">All</a>
+          <a href="{{site.baseurl}}/">门扉</a>
         </li>
         <li class="c-nav__item c-item_post" data-filter="Daily">
           <a href="{{site.baseurl}}/?cat=Daily">Daily</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,7 +15,7 @@
     <nav class="c-nav" aria-label="Primary">
       <ul class="c-nav__list u-lists-reset">
         <li class="c-nav__item c-item_post{% if nav_active == 'all' %} is-active{% endif %}" data-filter="all">
-          <a href="{{site.baseurl}}/">门扉</a>
+          <a href="{{site.baseurl}}/">Home</a>
         </li>
         <li class="c-nav__item c-item_post" data-filter="Daily">
           <a href="{{site.baseurl}}/?cat=Daily">Daily</a>

--- a/_sass/5-components/_header.scss
+++ b/_sass/5-components/_header.scss
@@ -22,38 +22,18 @@
 }
 
 .c-brand {
-  font-family: $heading-font-family;
-  font-size: 20px;
-  font-weight: 700;
-  letter-spacing: 0.01em;
-  color: $ink;
-  text-decoration: none;
-  white-space: nowrap;
   display: inline-flex;
-  align-items: baseline;
-  gap: 0;
+  align-items: center;
+  text-decoration: none;
   transition: $global-transition;
   &:hover {
-    color: $accent;
-    .c-brand__mark { color: $accent; }
+    transform: translateY(-1px);
   }
-  .c-brand__mark {
-    font-style: italic;
-    font-weight: 700;
-    color: $accent;
-    transition: $global-transition;
-  }
-  .c-brand__rest {
-    font-weight: 400;
-  }
-  .c-brand__dot {
-    display: inline-block;
-    width: 5px;
-    height: 5px;
-    border-radius: 50%;
-    background-color: $accent;
-    margin-left: 4px;
-    transform: translateY(-2px);
+  .c-brand__emoji {
+    font-size: 26px;
+    line-height: 1;
+    letter-spacing: -0.05em;
+    user-select: none;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ layout: home
   </a>
   {% endif %}
 
-  <div class="c-hero__eyebrow">Notes from Wonderland</div>
+  <div class="c-hero__eyebrow">A Personal Blog</div>
   <h1 class="c-hero__title">Winter in <em>Wonderland</em></h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>


### PR DESCRIPTION
## Summary

Three small homepage refinements:

**1. Brand mark → ❄️☀️**
The "Winter ·" wordmark in the topbar becomes a tiny rebus of 冬璇 / Winter Sun. More personal and visually lighter than typeset initials.

**2. Hero eyebrow → "A Personal Blog"**
The line above "Winter in Wonderland" was poetic but didn't actually say what the site is. Now it announces "this is a blog".

**3. Home tab → "Home"**
"ALL" was generic and duplicated the brand mark's function. Renamed to **Home** — clearer English that fits the same register as Daily / Novel / Sam / About.

## Test plan
- [ ] Topbar shows ❄️☀️ on the left where "Winter ·" used to be
- [ ] Hero eyebrow reads "A PERSONAL BLOG"
- [ ] Leftmost tab reads "Home" and still acts as the All / home filter
- [ ] Mobile (≤480px) still fits everything in the topbar

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY