### PR TITLE
Add dark mode (system-aware + manual toggle)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,6 +8,18 @@
   <link rel='shotcut icon' href="{{site.baseurl}}/images/{% if site.author-image %}{{site.author-image}}{% endif %}">
   <link rel='canonical' href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel='alternate' type='application/rss+xml' title='{{ site.title }}' href="{{ '/feed.xml' | prepend: site.baseurl | prepend: site.url }}">
+  <!-- Set theme before paint to avoid flash -->
+  <script>
+    (function () {
+      try {
+        var saved = localStorage.getItem('wiw-theme');
+        if (saved === 'dark' || saved === 'light') {
+          document.documentElement.setAttribute('data-theme', saved);
+        }
+      } catch (e) { /* ignore */ }
+    })();
+  </script>
+
   <!-- Fonts -->
   <link href="https://fonts.googleapis.com/css?family=Volkhov:400,700" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -52,5 +52,10 @@
       </div>
       <ul id="js-results-container" class="c-search-results-list"></ul>
     </div>
+
+    <button class="c-theme-toggle" type="button" id="js-theme-toggle" aria-label="Toggle dark mode">
+      <span class="c-theme-toggle__icon c-theme-toggle__icon--sun" aria-hidden="true">☀</span>
+      <span class="c-theme-toggle__icon c-theme-toggle__icon--moon" aria-hidden="true">☾</span>
+    </button>
   </div>
 </header>

--- a/_sass/0-settings/_colors.scss
+++ b/_sass/0-settings/_colors.scss
@@ -2,28 +2,96 @@
 	COLORS
 =============== */
 
-// Brand & accents
-$accent:           #b85c5c; // dusty rose accent
-$accent-soft:      #d3938b;
-$accent-dark:      darken($accent, 8%);
+:root {
+  /* ===== Light theme (default) ===== */
+  --c-bg:            #f7f3ec;       // page background (warm cream)
+  --c-bg-soft:       #fbf8f1;       // alt surface
+  --c-paper:         #ffffff;       // card surface
+  --c-ink:           #1f1d1a;       // primary text
+  --c-ink-soft:      #3d3833;       // body text
+  --c-muted:         #8a8074;       // muted text
+  --c-muted-soft:    #b6ac9d;       // very muted
+  --c-line:          #e6dfd2;       // hairline
+  --c-line-strong:   #cfc6b4;       // stronger line
+  --c-accent:        #b85c5c;       // dusty rose
+  --c-accent-soft:   #d3938b;
+  --c-accent-dark:   #9c4848;       // hover
+  --c-status-red:    #c0594a;
+  --c-status-green:  #6b8a5b;
+  --c-paper-fixed:   #ffffff;       // stays white in both themes
+  /* RGB triples for runtime opacity */
+  --rgb-shadow:      31, 29, 26;
+  --rgb-accent:      184, 92, 92;
+  --rgb-line-warm:   212, 196, 176;
+  --rgb-paper:       255, 255, 255;
+  --rgb-bg:          247, 243, 236;
+}
 
-// Ink
-$ink:              #1f1d1a;
-$ink-soft:         #3d3833;
-$muted:            #8a8074;
-$muted-soft:       #b6ac9d;
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --c-bg:            #1a1815;
+    --c-bg-soft:       #211f1a;
+    --c-paper:         #24211d;
+    --c-ink:           #efe8da;
+    --c-ink-soft:      #c8c0b1;
+    --c-muted:         #948a7c;
+    --c-muted-soft:    #6e665b;
+    --c-line:          #322e28;
+    --c-line-strong:   #4a443c;
+    --c-accent:        #d97978;
+    --c-accent-soft:   #b06564;
+    --c-accent-dark:   #f08e8d;
+    --c-status-red:    #d97978;
+    --c-status-green:  #84a06f;
+    /* paper-fixed stays light */
+    --rgb-shadow:      0, 0, 0;
+    --rgb-accent:      217, 121, 120;
+    --rgb-line-warm:   60, 56, 50;
+    --rgb-paper:       36, 33, 29;
+    --rgb-bg:          26, 24, 21;
+  }
+}
 
-// Surfaces
-$cream:            #f7f3ec; // page background
-$paper:            #ffffff; // card surface
-$paper-warm:       #fbf8f1;
-$line:             #e6dfd2;
-$line-strong:      #cfc6b4;
+:root[data-theme="dark"] {
+  --c-bg:            #1a1815;
+  --c-bg-soft:       #211f1a;
+  --c-paper:         #24211d;
+  --c-ink:           #efe8da;
+  --c-ink-soft:      #c8c0b1;
+  --c-muted:         #948a7c;
+  --c-muted-soft:    #6e665b;
+  --c-line:          #322e28;
+  --c-line-strong:   #4a443c;
+  --c-accent:        #d97978;
+  --c-accent-soft:   #b06564;
+  --c-accent-dark:   #f08e8d;
+  --c-status-red:    #d97978;
+  --c-status-green:  #84a06f;
+  --rgb-shadow:      0, 0, 0;
+  --rgb-accent:      217, 121, 120;
+  --rgb-line-warm:   60, 56, 50;
+  --rgb-paper:       36, 33, 29;
+}
 
-// Status
-$red-color:        #c0594a;
-$green-color:      #6b8a5b;
-$white-color:      #ffffff;
+/* ===== SCSS variables that wrap the CSS custom properties ===== */
+$accent:           var(--c-accent);
+$accent-soft:      var(--c-accent-soft);
+$accent-dark:      var(--c-accent-dark);
+
+$ink:              var(--c-ink);
+$ink-soft:         var(--c-ink-soft);
+$muted:            var(--c-muted);
+$muted-soft:       var(--c-muted-soft);
+
+$cream:            var(--c-bg);
+$paper:            var(--c-paper);
+$paper-warm:       var(--c-bg-soft);
+$line:             var(--c-line);
+$line-strong:      var(--c-line-strong);
+
+$red-color:        var(--c-status-red);
+$green-color:      var(--c-status-green);
+$white-color:      var(--c-paper-fixed);
 
 // Legacy names — kept so other partials keep compiling
 $primary-color:    $accent;

--- a/_sass/5-components/_article-page.scss
+++ b/_sass/5-components/_article-page.scss
@@ -9,7 +9,7 @@
 
 .c-wrap-content {
   padding: 20px;
-  background-color: $white-color;
+  background-color: $paper;
 }
 
 .c-article__image {
@@ -69,10 +69,10 @@
       font-size: 10px;
       line-height: 10px;
       text-transform: uppercase;
-      background-color: rgba(115, 138, 160, 0.60);
-      color: $white-color;
+      background-color: $muted;
+      color: $paper;
       &:hover {
-        background-color: darken(rgba(115, 138, 160, 0.60), 15%);
+        background-color: $ink-soft;
       }
       &:last-child {
         margin-right: 0;
@@ -101,8 +101,8 @@
     border-radius: 10px;
     overflow: hidden;
     text-align: center;
-    background-color: $white-color;
-    box-shadow: 0 1px 1px 0 rgba(31,35,46,0.15);
+    background-color: $paper;
+    box-shadow: 0 1px 1px 0 rgba(var(--rgb-shadow), 0.15);
     transition: $global-transition;
     h4 {
       margin-bottom: 5px;

--- a/_sass/5-components/_buttons.scss
+++ b/_sass/5-components/_buttons.scss
@@ -30,9 +30,9 @@
   }
 
   &--shadow {
-    box-shadow: 8px 10px 20px 0 rgba(46, 61, 73, .15);
+    box-shadow: 8px 10px 20px 0 rgba(var(--rgb-shadow), 0.15);
     &:hover {
-      box-shadow: 2px 4px 8px 0px rgba(46, 61, 73, 0.2);
+      box-shadow: 2px 4px 8px 0px rgba(var(--rgb-shadow), 0.2);
     }
   }
 

--- a/_sass/5-components/_categories.scss
+++ b/_sass/5-components/_categories.scss
@@ -32,7 +32,7 @@
   &:hover {
     transform: translateY(-3px);
     border-color: $accent-soft;
-    box-shadow: 0 18px 40px -18px rgba(31, 29, 26, 0.18);
+    box-shadow: 0 18px 40px -18px rgba(var(--rgb-shadow), 0.18);
     .c-categories__more { opacity: 1; }
   }
 }
@@ -60,7 +60,7 @@
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: $paper;
-    background-color: rgba(31, 29, 26, 0.7);
+    background-color: rgba(var(--rgb-shadow), 0.7);
     border-radius: 999px;
     opacity: 0;
     transition: $global-transition;

--- a/_sass/5-components/_form.scss
+++ b/_sass/5-components/_form.scss
@@ -8,7 +8,7 @@
   width: calc(100% - 40px);
   min-height: 100vh;
   padding: 0 20px;
-  background-color: $white-color;
+  background-color: $paper;
   z-index: 1;
 }
 
@@ -61,7 +61,7 @@
     outline: none;
     transition: $global-transition;
     &:focus {
-      box-shadow: 0 4px 25px rgba(132, 135, 138, 0.1);
+      box-shadow: 0 4px 25px rgba(var(--rgb-shadow), 0.10);
     }
   }
   button {

--- a/_sass/5-components/_header.scss
+++ b/_sass/5-components/_header.scss
@@ -7,7 +7,7 @@
   top: 0;
   z-index: 50;
   width: 100%;
-  background-color: rgba(247, 243, 236, 0.92);
+  background-color: rgba(var(--rgb-bg), 0.92);
   backdrop-filter: saturate(140%) blur(8px);
   -webkit-backdrop-filter: saturate(140%) blur(8px);
   border-bottom: 1px solid $line;
@@ -75,7 +75,7 @@
   }
   &:hover {
     color: $accent;
-    background-color: rgba(184, 92, 92, 0.06);
+    background-color: rgba(var(--rgb-accent), 0.06);
   }
   &.is-active {
     color: $paper;
@@ -115,7 +115,7 @@
     &:focus {
       border-color: $accent-soft;
       background-color: $paper;
-      box-shadow: 0 0 0 3px rgba(184, 92, 92, 0.12);
+      box-shadow: 0 0 0 3px rgba(var(--rgb-accent), 0.12);
     }
   }
   .c-search-results-list {
@@ -131,7 +131,7 @@
     background-color: $paper;
     border: 1px solid $line;
     border-radius: 12px;
-    box-shadow: 0 12px 40px -12px rgba(31, 29, 26, 0.18);
+    box-shadow: 0 12px 40px -12px rgba(var(--rgb-shadow), 0.18);
     z-index: 60;
     &:empty { display: none; }
     li {
@@ -188,6 +188,48 @@
   .c-brand {
     font-size: 17px;
   }
+}
+
+/* ===== Theme toggle ===== */
+.c-theme-toggle {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  margin-left: 8px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid $line;
+  border-radius: 999px;
+  color: $ink-soft;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  transition: $global-transition;
+  &:hover {
+    color: $accent;
+    border-color: $accent-soft;
+    background-color: rgba(var(--rgb-accent), 0.06);
+  }
+  .c-theme-toggle__icon {
+    display: none;
+  }
+}
+
+:root:not([data-theme="dark"]) .c-theme-toggle__icon--moon { display: inline; }
+:root[data-theme="dark"] .c-theme-toggle__icon--sun { display: inline; }
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) {
+    .c-theme-toggle__icon--moon { display: none; }
+    .c-theme-toggle__icon--sun { display: inline; }
+  }
+}
+
+@media only screen and (max-width: 480px) {
+  .c-theme-toggle { width: 32px; height: 32px; font-size: 14px; }
 }
 
 /* ===== legacy .c-header retained for post page (hidden via u-hide) ===== */

--- a/_sass/5-components/_hero.scss
+++ b/_sass/5-components/_hero.scss
@@ -56,7 +56,7 @@
     0 0 0 1px $line-strong,
     0 0 0 6px $paper,
     0 0 0 7px $line,
-    0 18px 40px -16px rgba(31, 29, 26, 0.20);
+    0 18px 40px -16px rgba(var(--rgb-shadow), 0.20);
   transition: $global-transition;
   &:hover {
     transform: translateY(-2px);
@@ -64,7 +64,7 @@
       0 0 0 1px $accent-soft,
       0 0 0 6px $paper,
       0 0 0 7px $line,
-      0 22px 44px -14px rgba(31, 29, 26, 0.26);
+      0 22px 44px -14px rgba(var(--rgb-shadow), 0.26);
   }
   img {
     width: 100%;

--- a/_sass/5-components/_index-post.scss
+++ b/_sass/5-components/_index-post.scss
@@ -17,7 +17,7 @@
   color: inherit;
   &:hover .c-featured__image-wrap {
     transform: translateY(-3px);
-    box-shadow: 0 30px 60px -20px rgba(31, 29, 26, 0.25);
+    box-shadow: 0 30px 60px -20px rgba(var(--rgb-shadow), 0.25);
   }
   &:hover .c-featured__title {
     color: $accent;
@@ -30,13 +30,13 @@
   overflow: hidden;
   aspect-ratio: 4 / 3;
   background-color: $line;
-  box-shadow: 0 18px 40px -18px rgba(31, 29, 26, 0.25);
+  box-shadow: 0 18px 40px -18px rgba(var(--rgb-shadow), 0.25);
   transition: $global-transition;
   &::after {
     content: "";
     position: absolute;
     inset: 0;
-    background: linear-gradient(180deg, transparent 60%, rgba(31, 29, 26, 0.10));
+    background: linear-gradient(180deg, transparent 60%, rgba(var(--rgb-shadow), 0.10));
     pointer-events: none;
   }
 }
@@ -125,7 +125,7 @@
   transition: $global-transition;
   &:hover .c-post__image-wrap {
     transform: translateY(-3px);
-    box-shadow: 0 24px 50px -20px rgba(31, 29, 26, 0.22);
+    box-shadow: 0 24px 50px -20px rgba(var(--rgb-shadow), 0.22);
   }
   &:hover .c-post__title {
     color: $accent;
@@ -138,7 +138,7 @@
   overflow: hidden;
   aspect-ratio: 16 / 10;
   background-color: $line;
-  box-shadow: 0 12px 28px -16px rgba(31, 29, 26, 0.20);
+  box-shadow: 0 12px 28px -16px rgba(var(--rgb-shadow), 0.20);
   transition: $global-transition;
   margin-bottom: 22px;
 }
@@ -225,8 +225,8 @@
   padding: 28px 30px;
   margin-bottom: 32px;
   background:
-    radial-gradient(circle at 88% 28%, rgba(184, 92, 92, 0.10), transparent 40%),
-    radial-gradient(circle at 12% 78%, rgba(212, 196, 176, 0.18), transparent 38%),
+    radial-gradient(circle at 88% 28%, rgba(var(--rgb-accent), 0.10), transparent 40%),
+    radial-gradient(circle at 12% 78%, rgba(var(--rgb-line-warm), 0.18), transparent 38%),
     $paper;
   border: 1px solid $line;
   border-radius: 4px;
@@ -246,7 +246,7 @@
   &:hover {
     transform: translateY(-3px);
     border-color: $accent-soft;
-    box-shadow: 0 22px 44px -22px rgba(31, 29, 26, 0.22);
+    box-shadow: 0 22px 44px -22px rgba(var(--rgb-shadow), 0.22);
     .c-feature-card__title { color: $accent; }
     .c-feature-card__cta { color: $accent; }
     .c-feature-card__tab { transform: translate(2px, -2px); }
@@ -324,11 +324,11 @@
   overflow: hidden;
   border-radius: 4px;
   background-color: $line;
-  box-shadow: 0 8px 22px -14px rgba(31, 29, 26, 0.25);
+  box-shadow: 0 8px 22px -14px rgba(var(--rgb-shadow), 0.25);
   transition: $global-transition;
   &:hover {
     transform: translateY(-3px);
-    box-shadow: 0 18px 36px -16px rgba(31, 29, 26, 0.35);
+    box-shadow: 0 18px 36px -16px rgba(var(--rgb-shadow), 0.35);
   }
   img {
     width: 100%;

--- a/_sass/5-components/_newsletter.scss
+++ b/_sass/5-components/_newsletter.scss
@@ -52,7 +52,7 @@
   outline: none;
   cursor: pointer;
   &:hover {
-    background-color: darken($primary-color, 15%);
+    background-color: $accent-dark;
   }
 }
 

--- a/_sass/5-components/_sam.scss
+++ b/_sass/5-components/_sam.scss
@@ -94,7 +94,7 @@
   &:hover {
     transform: translateY(-3px);
     border-color: $accent-soft;
-    box-shadow: 0 22px 44px -22px rgba(31, 29, 26, 0.22);
+    box-shadow: 0 22px 44px -22px rgba(var(--rgb-shadow), 0.22);
     .c-sam-card__title { color: $accent; }
     .c-sam-card__cta { color: $accent; }
     .c-sam-card__tab { transform: translate(2px, -2px); }

--- a/_sass/5-components/_tags.scss
+++ b/_sass/5-components/_tags.scss
@@ -6,7 +6,7 @@
   width: 100%;
   padding: 20px;
   margin: 20px 0 40px;
-  background-color: $white-color;
+  background-color: $paper;
   h1 {
     text-align: center;
     margin-bottom: 0;
@@ -32,7 +32,7 @@
       text-transform: uppercase;
       font-size: 12px;
       &:hover {
-        color: darken($text-color, 30%);
+        color: $ink;
       }
     }
   }

--- a/js/main.js
+++ b/js/main.js
@@ -184,6 +184,24 @@ $(document).ready(function () {
   });
 
   /* =======================
+  // Theme toggle (light / dark)
+  ======================= */
+
+  var themeToggle = document.getElementById('js-theme-toggle');
+  if (themeToggle) {
+    themeToggle.addEventListener('click', function () {
+      var current = document.documentElement.getAttribute('data-theme');
+      var systemDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      var next;
+      if (current === 'dark') next = 'light';
+      else if (current === 'light') next = 'dark';
+      else next = systemDark ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', next);
+      try { localStorage.setItem('wiw-theme', next); } catch (e) { /* ignore */ }
+    });
+  }
+
+  /* =======================
   // Scroll to top
   ======================= */
 


### PR DESCRIPTION
## Summary

Add a proper dark mode that follows the system by default and can be overridden with a sun/moon toggle in the topbar.

## How it works

- **Color tokens are now CSS custom properties** at `:root`. Light defaults; dark variants under `@media (prefers-color-scheme: dark)` and `:root[data-theme="dark"]` for manual override.
- SCSS variables wrap the CSS vars (`$accent: var(--c-accent)` etc.) so every existing partial keeps working with no code changes.
- For runtime opacity (shadows, accent tints), I expose **RGB triples** (`--rgb-shadow`, `--rgb-accent`, `--rgb-line-warm`, `--rgb-paper`, `--rgb-bg`) and rewrite all hardcoded `rgba(...)` calls across components to use `rgba(var(--rgb-shadow), 0.X)` etc. — shadows shift from warm-ink in light mode to true black in dark mode.
- Replaced remaining `darken()` / `lighten()` calls (which can't operate on CSS vars) with explicit hover variants like `$accent-dark` and `$ink`.

## UI

- ☾ / ☀ button in the topbar, right of the search. Shows the moon in light mode, the sun in dark, and the appropriate one if the user hasn't picked manually.
- Inline `<head>` script reads `localStorage('wiw-theme')` and sets `[data-theme]` on `<html>` **before first paint**, so refreshes don't flash the wrong theme.
- `main.js` click handler cycles light ↔ dark and persists.

## Dark palette

Keeps the site's warm character — dark warm-brown background instead of black, off-white warm text, slightly brighter dusty-rose accent so it still pops on the darker surface.

## Test plan
- [ ] First visit: respects OS dark mode preference
- [ ] Click sun/moon: toggles to opposite, persists across reloads
- [ ] Switch back: persists across reloads
- [ ] All components legible in dark: hero, post cards, Sam page, About, Gallery / NewYear card, footer
- [ ] No theme flash on refresh under either mode

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_