### PR TITLE
Align portrait position across heroes; show Sam Rockwell's full name

### DIFF
--- a/_sass/5-components/_hero.scss
+++ b/_sass/5-components/_hero.scss
@@ -18,10 +18,11 @@
 :root[data-hero-active="gallery"] [data-hero-id="gallery"] { display: block; }
 :root[data-hero-active="tags"] [data-hero-id="tags"] { display: block; }
 
-/* Compact filter hero — eyebrow + title + byline only.
-   Same typographic style as Sam/About, just no portrait/quote. */
+/* Compact filter hero — same portrait + eyebrow + title + byline.
+   Top padding matches .c-hero so portraits align across all tabs;
+   only the title size and bottom padding differ. */
 .c-hero--filter {
-  padding: 72px 0 56px;
+  padding: 80px 0 56px;
   .c-hero__title {
     font-size: 68px;
     margin-bottom: 30px;

--- a/sam/index.html
+++ b/sam/index.html
@@ -10,7 +10,7 @@ title: Sam
   </a>
   {% endif %}
 
-  <div class="c-hero__eyebrow">All about Sam</div>
+  <div class="c-hero__eyebrow">Sam Rockwell</div>
   <h1 class="c-hero__title">For <em>Sam</em></h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>


### PR DESCRIPTION
## Summary

Two small fixes:

1. **Portrait alignment** — `.c-hero--filter` had 72px top padding while `.c-hero` (About / Sam) had 80px, so the portrait sat 8px lower on Sam/About than on filter tabs. Bumped filter top padding to 80px so the portrait lands in the same place no matter which tab is active.

2. **Sam page eyebrow** — "All about Sam" → **Sam Rockwell** so the small text above "For Sam" actually names him.

## Test plan
- [ ] Switch between About / Daily / Novel / Sam — portrait stays at the same Y position
- [ ] Sam page eyebrow reads "SAM ROCKWELL"

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_