### PR TITLE
Switch body type to Cormorant Garamond + Noto Serif SC

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,8 +21,10 @@
   </script>
 
   <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css?family=Volkhov:400,700" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Noto+Serif+SC:wght@400;500;600;700&display=swap" rel="stylesheet">
 
   <style>
     {% capture include_to_scssify %}

--- a/_sass/0-settings/_typography.scss
+++ b/_sass/0-settings/_typography.scss
@@ -2,14 +2,15 @@
 	TYPOGRAPHY
 =============== */
 
-// Body font
-$base-font-size: 16px;
+// Body font — literary serif paired with Chinese serif, matching the
+// Many Faces of Sam page treatment.
+$base-font-size: 18px;
 $base-font-style: normal;
 $base-font-variant: normal;
-$base-font-weight: 400;
-$base-font-family: 'Open Sans', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', Helvetica, Arial, sans-serif;
+$base-font-weight: 500;
+$base-font-family: 'Cormorant Garamond', 'Noto Serif SC', 'Songti SC', Georgia, 'Times New Roman', serif;
 $base-line-height: 1.7;
 
-// Headings & display
+// Headings & display — keep Volkhov for the magazine-cover headlines
 $heading-font-weight: 400;
 $heading-font-family: 'Volkhov', 'Noto Serif SC', 'Songti SC', 'Times New Roman', Times, serif;


### PR DESCRIPTION
## Summary

Match the body type across the whole blog to the Many Faces of Sam page treatment — a literary serif voice in both English and Chinese.

- Add **Cormorant Garamond** (English) and **Noto Serif SC** (Chinese) via Google Fonts in `<head>`, with preconnect so they load fast.
- `_typography.scss` base font becomes `'Cormorant Garamond', 'Noto Serif SC', 'Songti SC', Georgia, serif` at weight 500, size 18px (slightly larger so the lighter serif stays comfortable to read).
- Headings keep Volkhov + Noto Serif SC for the magazine-cover headlines — only body text changes.

End result: hero prose, post paragraphs, Sam essay, About text — everything reads like the same quiet book.

## Test plan
- [ ] Sam page intro paragraphs now in serif (matches Many Faces style)
- [ ] Homepage About prose in serif
- [ ] Post body in serif
- [ ] Headings unchanged (still Volkhov)

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_