### PR TITLE
Loosen body leading; tab title becomes "Page · Site"

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
   <meta http-equiv='X-UA-Compatible' content='IE=edge'>
   <meta name='viewport' content='width=device-width, initial-scale=1'>
 
-  <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+  <title>{% if page.title and page.url != '/' %}{{ page.title }} · {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name='description' content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   <link rel='shotcut icon' href="{{site.baseurl}}/images/{% if site.author-image %}{{site.author-image}}{% endif %}">
   <link rel='canonical' href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">

--- a/_sass/0-settings/_typography.scss
+++ b/_sass/0-settings/_typography.scss
@@ -9,7 +9,7 @@ $base-font-style: normal;
 $base-font-variant: normal;
 $base-font-weight: 500;
 $base-font-family: 'Cormorant Garamond', 'Noto Serif SC', 'Songti SC', Georgia, 'Times New Roman', serif;
-$base-line-height: 1.7;
+$base-line-height: 1.85;
 
 // Headings & display — keep Volkhov for the magazine-cover headlines
 $heading-font-weight: 400;


### PR DESCRIPTION
## Summary

Two small finishing touches:

1. **Body leading** — line-height 1.7 → 1.85 so paragraphs breathe more, especially helpful for the new Cormorant Garamond + Noto Serif SC pairing where the lighter serif benefits from extra leading.

2. **Browser tab title** — was just "Sam" on `/sam/` because `page.title` overrode `site.title` directly. Use **"{Page} · Winter in Wonderland"** everywhere except the homepage (which keeps just the site title). So:
   - `/` → `Winter in Wonderland`
   - `/sam/` → `Sam · Winter in Wonderland`
   - post pages → `故事终结之处 · Winter in Wonderland`

## Test plan
- [ ] Body paragraphs (Sam page, posts, About) read with more spacious leading
- [ ] Browser tab on `/sam/` shows "Sam · Winter in Wonderland"
- [ ] Browser tab on `/` shows just "Winter in Wonderland"

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_