### PR TITLE
Switch English serif to EB Garamond; remove broken Valine comments

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,7 +24,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css?family=Volkhov:400,700" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Noto+Serif+SC:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Noto+Serif+SC:wght@400;500;600;700&display=swap" rel="stylesheet">
 
   <style>
     {% capture include_to_scssify %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,18 +28,6 @@ layout: home
       </header>
       {{page.content | markdownify}}
 
-      <div id="valine-comments">
-        <script type="text/javascript" src="//unpkg.com/valine/dist/Valine.min.js"></script>
-        <script type="text/javascript">
-            console.log("this is valine comments")
-            new Valine({
-                el: '#valine-comments',
-                appId: '1289CUYr7bmBOIe8rqJnDKfv-gzGzoHsz',
-                appKey: 'EgK4tADjLrGwMOfObtf3Lx4Z'
-            })
-        </script>
-    </div>
-      
       <div class="c-recent-post">
         {% if site.related_posts %}
         <h4 class="c-recent__title">YOU MIGHT ALSO ENJOY</h4>

--- a/_sass/0-settings/_typography.scss
+++ b/_sass/0-settings/_typography.scss
@@ -8,7 +8,7 @@ $base-font-size: 18px;
 $base-font-style: normal;
 $base-font-variant: normal;
 $base-font-weight: 500;
-$base-font-family: 'Cormorant Garamond', 'Noto Serif SC', 'Songti SC', Georgia, 'Times New Roman', serif;
+$base-font-family: 'EB Garamond', 'Noto Serif SC', 'Songti SC', Georgia, 'Times New Roman', serif;
 $base-line-height: 1.85;
 
 // Headings & display — keep Volkhov for the magazine-cover headlines


### PR DESCRIPTION
## Summary

Two fixes from the latest review:

**1. English body serif → EB Garamond**
Cormorant Garamond is a display serif and read too thin at body size — numbers especially were hard to make out. Swap to **EB Garamond** (same Garamond family lineage, built for body text), with stronger numerals and better readability while keeping the literary tone.

**2. Remove broken Valine comments**
The Valine block on every post was hitting LeanCloud's `Code 504: The app is archived` error and showing a broken comment form to readers. Pulled out of `_layouts/post.html`.

If you want comments back later, **giscus** (uses your repo's GitHub Discussions, free, auto-themes with the page) is a clean drop-in — say the word and I'll wire it up.

## Test plan
- [ ] Sam intro paragraphs read clearly, English words like "Leslie" don't feel washed out
- [ ] Numbers in Chinese sentences (e.g. dates) are legible
- [ ] Post page no longer shows a broken comment form

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_