### PR TITLE
Topbar portrait button: two-step scroll-to-top, then home

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,6 +6,12 @@
     {% elsif page.url == '/' or page.url == '/index.html' or page.url == '/about/' %}{% assign nav_active = 'about' %}
     {% endif %}
 
+    <button class="c-scroll-top" type="button" id="js-scroll-top" aria-label="Scroll to top">
+      {% if site.author-image %}
+      <img src="{{site.baseurl}}/images/{{site.author-image}}" alt="">
+      {% endif %}
+    </button>
+
     <nav class="c-nav" aria-label="Primary">
       <ul class="c-nav__list u-lists-reset">
         <li class="c-nav__item c-nav__item--link{% if nav_active == 'about' %} is-active{% endif %}">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
     {% elsif page.url == '/' or page.url == '/index.html' or page.url == '/about/' %}{% assign nav_active = 'about' %}
     {% endif %}
 
-    <button class="c-scroll-top" type="button" id="js-scroll-top" aria-label="Scroll to top">
+    <button class="c-scroll-top" type="button" id="js-scroll-top" aria-label="Scroll to top — click again to go home" title="Top of page (click again to go home)">
       {% if site.author-image %}
       <img src="{{site.baseurl}}/images/{{site.author-image}}" alt="">
       {% endif %}

--- a/_sass/0-settings/_colors.scss
+++ b/_sass/0-settings/_colors.scss
@@ -71,6 +71,7 @@
   --rgb-accent:      217, 121, 120;
   --rgb-line-warm:   60, 56, 50;
   --rgb-paper:       36, 33, 29;
+  --rgb-bg:          26, 24, 21;
 }
 
 /* ===== SCSS variables that wrap the CSS custom properties ===== */

--- a/_sass/5-components/_header.scss
+++ b/_sass/5-components/_header.scss
@@ -190,6 +190,39 @@
   }
 }
 
+/* ===== Scroll-to-top portrait button (top-left, symmetric with theme toggle) ===== */
+.c-scroll-top {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  margin-right: 12px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid $line;
+  border-radius: 999px;
+  cursor: pointer;
+  overflow: hidden;
+  transition: $global-transition;
+  &:hover {
+    border-color: $accent-soft;
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px -8px rgba(var(--rgb-shadow), 0.30);
+  }
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+@media only screen and (max-width: 480px) {
+  .c-scroll-top { width: 32px; height: 32px; margin-right: 8px; }
+}
+
 /* ===== Theme toggle ===== */
 .c-theme-toggle {
   flex-shrink: 0;

--- a/js/main.js
+++ b/js/main.js
@@ -211,9 +211,18 @@ $(document).ready(function () {
 
   $('.c-top').click(smoothScrollToTop);
 
+  // Top-left portrait: first click scrolls to top, click again to go home
   var scrollTopBtn = document.getElementById('js-scroll-top');
   if (scrollTopBtn) {
-    scrollTopBtn.addEventListener('click', smoothScrollToTop);
+    scrollTopBtn.addEventListener('click', function () {
+      var atTop = window.scrollY <= 4;
+      if (!atTop) {
+        smoothScrollToTop();
+      } else if (!isHomepage()) {
+        window.location.href = BASEURL + '/';
+      }
+      // else: already home + at top, nothing useful to do
+    });
   }
   $(window).scroll(function () {
     if ($(this).scrollTop() > $(window).height()) {

--- a/js/main.js
+++ b/js/main.js
@@ -205,9 +205,16 @@ $(document).ready(function () {
   // Scroll to top
   ======================= */
 
-  $('.c-top').click(function () {
+  function smoothScrollToTop() {
     $('html, body').stop().animate({ scrollTop: 0 }, 'slow', 'swing');
-  });
+  }
+
+  $('.c-top').click(smoothScrollToTop);
+
+  var scrollTopBtn = document.getElementById('js-scroll-top');
+  if (scrollTopBtn) {
+    scrollTopBtn.addEventListener('click', smoothScrollToTop);
+  }
   $(window).scroll(function () {
     if ($(this).scrollTop() > $(window).height()) {
       $('.c-top').addClass("c-top--active");


### PR DESCRIPTION
## Summary

Mirror the moon toggle on the **left** side of the topbar with a small round **portrait button** that has a two-step behavior:

- **Mid-page** → smooth scroll to the top of the current page
- **Already at the top** → navigate home
- **Already home and at top** → no-op (don't bother reloading)

Matches a reader's natural rhythm — *let me look at the top, ok now take me back* — without ever jumping them out of an article they're still reading. The explicit hero portrait stays as the guaranteed one-click home link.

Same 36px circle as the moon toggle, same hover lift, symmetric topbar layout (portrait left ↔ moon right).

Also fix a missed dark-mode token: `--rgb-bg` wasn't defined under `:root[data-theme="dark"]`, so when manually toggling to dark, the sticky topbar's translucent background was still showing the light cream value. Added.

## Test plan
- [ ] Topbar shows a round avatar on the left, moon on the right
- [ ] Click avatar mid-article → smooth scroll to top, stays on same page
- [ ] At top of an article, click again → navigates home
- [ ] At top of homepage, click → nothing happens (no flash/reload)
- [ ] Hero portrait below still goes home directly
- [ ] Manually toggle to dark — topbar background goes dark too

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY