### PR TITLE
Fix AU Story filter — quote the multi-word category

### DIFF
--- a/_posts/2026-05-01-sam-bell-moon-au-chapter-1-departure.md
+++ b/_posts/2026-05-01-sam-bell-moon-au-chapter-1-departure.md
@@ -3,7 +3,7 @@ layout: post
 title: "Chapter 1 · Departure — Sam Bell · Moon AU"
 date: 2026-05-01
 tags: [Sam, AU, Moon, 中文]
-categories: AU Story
+categories: ["AU Story"]
 summary: "氦-3反噬之后，地球开始慢性死亡。你二十六岁，带着研发了五年的合成药剂启程——它能修复所有Sam Bell体内被工业化写入的衰老程序。一同上船的，还有Sam 6——他执意要陪你回到那个曾经把他当作工具的月球基地。Sarang，韩语里是「爱」。"
 ---
 


### PR DESCRIPTION
## Problem

After Chapter 1 deployed, the post showed up on the homepage *All Stories* feed and on the Sam page card, but the **AU Story** tab filter showed *"Nothing filed here yet."* The post card's eyebrow also read **"AU"** instead of **"AU Story"**.

## Root cause

Front matter:

```yaml
categories: AU Story
```

Jekyll's YAML parser splits an unquoted value containing whitespace into a list. `categories: AU Story` becomes `["AU", "Story"]` — two categories, not one.

Consequences:
- `{{ post.categories | first }}` rendered as `"AU"`, so the post card's `data-category` attribute was `"AU"`.
- The AU Story nav button filters on `cat === "AU Story"`, which never matched, so the filter showed the empty state.

## Fix

```yaml
categories: ["AU Story"]
```

Forces YAML to read the value as a single string. The post now lands in the AU Story tab and renders the eyebrow as `"AU Story"`.

## Note for future chapters

Multi-word categories must be quoted or array-listed in front matter. `categories: ["AU Story"]` (or the multi-line list form) is the safe pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCYAvpnGLWvxwEusuuikKA)_