### PR TITLE
Search post body, not just titles

### DIFF
--- a/search.json
+++ b/search.json
@@ -4,11 +4,12 @@ layout: null
 [
   {% for post in site.posts %}
     {
-      "title"    : "{{ post.title | escape }}",
-      "category" : "{{ post.category }}",
-      "tags"     : "{{ post.tags | array_to_sentence_string }}",
+      "title"    : {{ post.title | jsonify }},
+      "category" : {{ post.categories | join: ", " | jsonify }},
+      "tags"     : {{ post.tags | join: ", " | jsonify }},
       "url"      : "{{ site.baseurl }}{{ post.url }}",
-      "date"     : "{{ post.date }}"
+      "date"     : "{{ post.date }}",
+      "content"  : {{ post.content | strip_html | strip_newlines | jsonify }}
     } {% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
## Summary

The search box only ever matched post titles because `search.json` carried just title / category / tags / url / date. Add a `content` field with the post body (HTML stripped, newlines flattened, jsonified for safe escaping) so searches now match any phrase that appears anywhere in a post.

Verified locally:
- "Sam" → 2 posts that mention Sam in the body (not in titles)
- "Fray" → 4 posts that mention "The Fray" in the body
- "冬璇" still works for any post mentioning the author

Also switched the other text fields to `| jsonify` for proper escaping (handles quotes, backslashes, etc) and fixed `post.category` → `post.categories` (the non-plural was always empty).

## Test plan
- [ ] Type a phrase from a post body into the search box → that post shows up in the dropdown
- [ ] Title-only matches still work
- [ ] No JS errors when posts contain quotes or special characters

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_