### PR TITLE
Fix Chapter 2 date a second time — UTC build time vs local thinking

### DIFF
--- a/_posts/2026-05-01-sam-bell-moon-au-chapter-2-awakening.md
+++ b/_posts/2026-05-01-sam-bell-moon-au-chapter-2-awakening.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Chapter 2 · Awakening — Sam Bell · Moon AU"
-date: 2026-05-01 23:00:00
+date: 2026-05-01 12:00:00
 image: sam-bell-moon-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]


### PR DESCRIPTION
## Why Chapter 2 still didn't appear after PR #49 merged

PR #49 changed Chapter 2's date from `2026-05-02` to `2026-05-01 23:00:00` to fix the future-date issue. But GitHub Actions runs in **UTC** — the build that ran post-merge of PR #49 saw UTC time `~20:29`, which means `23:00` was still **2.5 hours in the future**. Jekyll skipped it again.

## Fix

`date: 2026-05-01 23:00:00` → `date: 2026-05-01 12:00:00`

Noon UTC — safely past the build clock. Still sorts after Chapter 1 (whose date defaults to midnight).

After merging this, the Actions build should publish Chapter 2 properly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCYAvpnGLWvxwEusuuikKA)_