### PR TITLE
Reflect the active filter in the browser tab title

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,19 @@ layout: home
     else if (p.get('view') === 'gallery') active = 'gallery';
     else if (p.get('view') === 'tags') active = 'tags';
     document.documentElement.setAttribute('data-hero-active', active);
+
+    // Reflect the active filter in the browser tab title
+    var labels = {
+      'Daily': 'Daily',
+      'Novel': 'Novel',
+      'AU Story': 'AU Story',
+      'Lyrics': 'Lyrics',
+      'gallery': 'Gallery',
+      'tags': 'Tags'
+    };
+    if (labels[active]) {
+      document.title = labels[active] + ' · {{ site.title | escape }}';
+    }
   } catch (e) { /* fall back to default */ }
 })();
 </script>

--- a/js/main.js
+++ b/js/main.js
@@ -77,8 +77,30 @@ $(document).ready(function () {
     $item.addClass('is-active');
   }
 
+  // Cache the site title (last segment of the page title, or the
+  // whole thing if there's no " · " separator).
+  var SITE_TITLE_BASE = (function () {
+    var t = document.title || '';
+    var i = t.indexOf(' · ');
+    return i > 0 ? t.slice(i + 3) : t;
+  }());
+
+  var HERO_LABELS = {
+    'Daily': 'Daily',
+    'Novel': 'Novel',
+    'AU Story': 'AU Story',
+    'Lyrics': 'Lyrics',
+    'gallery': 'Gallery',
+    'tags': 'Tags'
+  };
+
   function setActiveHero(name) {
     document.documentElement.setAttribute('data-hero-active', name);
+    if (HERO_LABELS[name]) {
+      document.title = HERO_LABELS[name] + ' · ' + SITE_TITLE_BASE;
+    } else {
+      document.title = SITE_TITLE_BASE;
+    }
   }
 
   // On homepage: intercept filter / view clicks


### PR DESCRIPTION
## Summary

Daily / Novel / AU Story / Lyrics / Gallery / Tags are URL params on the homepage, so Liquid never saw them — every filter view kept the bare "Winter in Wonderland" tab title. Only Sam (a separate page with its own front matter) was getting the "Page · Site" treatment.

Now every tab reflects in the browser title:

| Route | Tab title |
|---|---|
| `/` | Winter in Wonderland |
| `/?cat=Daily` | Daily · Winter in Wonderland |
| `/?cat=Novel` | Novel · Winter in Wonderland |
| `/?cat=AU+Story` | AU Story · Winter in Wonderland |
| `/?cat=Lyrics` | Lyrics · Winter in Wonderland |
| `/?view=gallery` | Gallery · Winter in Wonderland |
| `/?view=tags` | Tags · Winter in Wonderland |
| `/sam/` | Sam · Winter in Wonderland |

The pre-paint inline script in `index.html` sets the title from URL params on first paint, and `main.js`'s `setActiveHero()` updates it live when the user clicks a filter tab — no reload needed.

## Test plan
- [ ] Direct visit `/?cat=Daily` → tab reads "Daily · Winter in Wonderland"
- [ ] Click a filter chip from any other view → tab title updates instantly
- [ ] Click About from a filter view → tab title resets to "Winter in Wonderland"

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_