### PR TITLE
Cache-bust main.js so click handlers always load fresh

### DIFF
--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -1,7 +1,8 @@
 <script>window.SITE_BASEURL = "{{site.baseurl}}";</script>
+{% assign cache_bust = site.time | date: '%Y%m%d%H%M' %}
 <script src="{{site.baseurl}}/js/jquery-3.3.1.min.js"></script>
 <script src="{{site.baseurl}}/js/evil-icons.min.js"></script>
 <script src="{{site.baseurl}}/js/jquery.fitvids.js"></script>
 <script src="{{site.baseurl}}/js/simple-jekyll-search.min.js"></script>
-<script src="{{site.baseurl}}/js/main.js"></script>
+<script src="{{site.baseurl}}/js/main.js?v={{ cache_bust }}"></script>
 <!-- /javascripts -->


### PR DESCRIPTION
## Summary

Tab-title-on-click was only seeming to work after a hard refresh because the browser had cached the **old** `main.js`:

- The inline script in `index.html` runs every page load, so refreshing on `/?cat=Daily` correctly set the tab title to "Daily · Winter in Wonderland".
- But clicking another filter chip (Daily → Novel) is intercepted by `main.js`'s `setActiveHero()`, and the cached version of `main.js` didn't have the title-update branch — so the title stayed "Daily · …" until the next refresh.

Fix: append a build-time timestamp to the `main.js` URL (`?v=YYYYMMDDHHMM`) so every deploy pushes a fresh URL. Browsers fetch it fresh, and the click-to-update logic works without anyone needing to hard refresh.

## Test plan
- [ ] After this deploys, refresh once on `/?cat=Daily`
- [ ] Click Novel → tab title becomes "Novel · Winter in Wonderland" without needing another refresh
- [ ] Click About → tab title becomes "Winter in Wonderland"
- [ ] Future code changes to main.js: every deploy auto-busts the cache, no manual versioning needed

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_