### PR TITLE
Introduce series concept — AU Story tab folds chapters into a collection card

### DIFF
--- a/_posts/2026-05-01-sam-bell-moon-au-chapter-1-departure.md
+++ b/_posts/2026-05-01-sam-bell-moon-au-chapter-1-departure.md
@@ -5,6 +5,8 @@ date: 2026-05-01
 image: sam-bell-moon-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]
+series: "Sam Bell · Moon AU"
+series_order: 1
 summary: "氦-3反噬之后，地球开始慢性死亡。你二十六岁，带着研发了五年的合成药剂启程——它能修复所有Sam Bell体内被工业化写入的衰老程序。一同上船的，还有Sam 6——他执意要陪你回到那个曾经把他当作工具的月球基地。Sarang，韩语里是「爱」。"
 ---
 

--- a/_posts/2026-05-01-sam-bell-moon-au-chapter-2-awakening.md
+++ b/_posts/2026-05-01-sam-bell-moon-au-chapter-2-awakening.md
@@ -5,6 +5,8 @@ date: 2026-05-01 12:00:00
 image: sam-bell-moon-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]
+series: "Sam Bell · Moon AU"
+series_order: 2
 summary: "四天的航行后，你和 Sam 6 在 Sarang 着陆。GERTY 用合成嗓音说了一句 Welcome home。医务室里，刚刚完整苏醒不久的 Sam 7 坐在冷冻舱沿，回头看你——他张口的第一句话不是「你是谁」。这一晚之后，三个人决定一起去把还留在事故矿车里的 Sam 5 接回家。"
 ---
 

--- a/index.html
+++ b/index.html
@@ -168,9 +168,37 @@ layout: home
   </div>
 
   <div class="c-post-grid">
+    {% comment %}
+      Series cards — one per unique series. Hidden on the "all" view (which shows
+      individual chapters); shown when their parent category is the active filter,
+      replacing the per-chapter cards for that series.
+    {% endcomment %}
+    {% assign all_series = site.posts | map: "series" | uniq | compact %}
+    {% for series_name in all_series %}
+      {% assign series_posts = site.posts | where: "series", series_name | sort: "series_order" %}
+      {% assign series_first = series_posts | first %}
+      {% assign series_cat = series_first.categories | first %}
+      {% assign series_count = series_posts | size %}
+      {% assign series_slug = series_name | slugify %}
+    <a class="c-post c-post--series is-hidden" href="{{ site.baseurl }}/series/{{ series_slug }}/" data-category="{{ series_cat }}" data-card-type="series" target="_blank" rel="noopener">
+      <div class="c-post__image-wrap">
+        {% if series_first.image %}
+        <div class="c-post__image" style="background-image: url('{{ "/images/" | prepend: site.baseurl | append: series_first.image }}')"></div>
+        {% else %}
+        <div class="c-post__placeholder">{{ series_cat | default: "Series" }}</div>
+        {% endif %}
+      </div>
+      <div class="c-post__body">
+        <div class="c-post__eyebrow">{{ series_cat }} · Series</div>
+        <h3 class="c-post__title">{{ series_name }}</h3>
+        <p class="c-post__summary">{{ series_count }} chapter{% if series_count != 1 %}s{% endif %} · ongoing</p>
+      </div>
+    </a>
+    {% endfor %}
+
     {% for post in site.posts %}
     {% assign post_cat = post.categories | first %}
-    <a class="c-post" href="{{ post.url | prepend: site.baseurl }}" data-category="{{ post_cat }}"{% if post_cat == 'AU Story' %} target="_blank" rel="noopener"{% endif %}>
+    <a class="c-post" href="{{ post.url | prepend: site.baseurl }}" data-category="{{ post_cat }}" data-card-type="chapter"{% if post.series %} data-series="{{ post.series }}"{% endif %}{% if post_cat == 'AU Story' %} target="_blank" rel="noopener"{% endif %}>
       <div class="c-post__image-wrap">
         {% if post.image %}
         <div class="c-post__image" style="background-image: url('{{ "/images/" | prepend: site.baseurl | append: post.image }}')"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -49,7 +49,27 @@ $(document).ready(function () {
     var visible = 0;
     $items.each(function () {
       var cat = $(this).attr('data-category') || '';
-      if (filter === 'all' || cat === filter) {
+      var cardType = $(this).attr('data-card-type') || 'chapter';
+      var partOfSeries = !!$(this).attr('data-series');
+
+      // Rules:
+      //   - 'all' view: show chapter cards (each post once); hide series
+      //     cards so series don't duplicate the chapters they group.
+      //   - Specific category: show series cards in that category; show
+      //     chapter cards in that category only if the chapter is NOT
+      //     part of a series (its series card represents it instead).
+      var shouldShow;
+      if (filter === 'all') {
+        shouldShow = cardType !== 'series';
+      } else if (cat !== filter) {
+        shouldShow = false;
+      } else if (cardType === 'series') {
+        shouldShow = true;
+      } else {
+        shouldShow = !partOfSeries;
+      }
+
+      if (shouldShow) {
         $(this).removeClass('is-hidden');
         visible++;
       } else {

--- a/sam/index.html
+++ b/sam/index.html
@@ -87,7 +87,7 @@ title: Sam
       <span class="c-sam-card__cta">Open in new tab →</span>
     </a>
 
-    <a class="c-sam-card" href="{{site.baseurl}}/?cat=AU+Story" target="_blank" rel="noopener">
+    <a class="c-sam-card" href="{{site.baseurl}}/series/sam-bell-moon-au/" target="_blank" rel="noopener">
       <div class="c-sam-card__eyebrow">AU Story · Series <span class="c-sam-card__tab">↗</span></div>
       <h4 class="c-sam-card__title">Sam Bell · Moon AU</h4>
       <p class="c-sam-card__desc">

--- a/series/sam-bell-moon-au/index.html
+++ b/series/sam-bell-moon-au/index.html
@@ -1,0 +1,89 @@
+---
+layout: home
+title: "Sam Bell · Moon AU"
+permalink: /series/sam-bell-moon-au/
+---
+
+<section class="c-hero">
+  {% if site.author-image %}
+  <a class="c-hero__portrait" href="{{site.baseurl}}/" aria-label="Home">
+    <img src="{{site.baseurl}}/images/{{site.author-image}}" alt="{{site.author-name}}">
+  </a>
+  {% endif %}
+
+  <div class="c-hero__eyebrow">AU Story · Series</div>
+  <h1 class="c-hero__title">Sam Bell · <em>Moon AU</em></h1>
+  <div class="c-hero__byline">
+    <span class="c-hero__byline-rule"></span>
+    <span class="c-hero__byline-text">an AU of Moon (2009) · ongoing</span>
+    <span class="c-hero__byline-rule"></span>
+  </div>
+
+  <p class="c-hero__lede">
+    <span class="c-hero__quote">&ldquo;</span>
+    那里有一整屋的他，等你们去唤醒。
+    <span class="c-hero__quote c-hero__quote--end">&rdquo;</span>
+  </p>
+</section>
+
+<article class="c-sam-intro">
+  <h2 class="c-sam-intro__heading">关于这个系列</h2>
+
+  <p>
+    《月球》（<em>Moon</em>, 2009）是 Sam Rockwell 一个人撑起整部电影的孤独之作。地下沉睡舱里那一整列被工业化生产、被预设三年寿命、被做成"用完就处理掉的工具"的 Sam Bell——他们一直在我心里没消失。
+  </p>
+
+  <p>这是关于他们的另一种结局。</p>
+
+  <p>
+    原片之后——Sam 6 撞掉了 Sarang 基地的干扰天线、藏进一罐氦-3 的运输舱、回到了那个从未真正属于他的地球，曝光了 Lunar Industries 的整个运转方式。然后是这个 AU 的世界：氦-3 反噬让地球文明开始慢性死亡，"你"——一个 26 岁的合成生物学家，研发出能修复克隆体衰老程序的合成药剂、却被伦理委员会冻结的那个——决定前往 Sarang 基地，把那一百多位还沉睡的 Sam 一个一个唤醒。
+  </p>
+
+  <p>
+    Sam 6 没让你一个人去。他在登舱口拦住你，怀里抱着旅行袋，眨眨眼说：「你没说过那个不是 Sam Bell 的人不能带一个 Sam Bell 一起去。」
+  </p>
+
+  <p>
+    这个系列写的是你们三个——你、Sam 6、刚被唤醒的 Sam 7——以及之后慢慢被唤醒的更多 Sam——重新把这家公司当年没给他们的「我们」，一个一个找回来的故事。
+  </p>
+
+  <p class="c-sam-intro__closing">
+    Sarang，韩语里是「爱」的意思。<br>
+    会一章一章慢慢长。
+  </p>
+</article>
+
+{% assign chapters = site.posts | where: "series", "Sam Bell · Moon AU" | sort: "series_order" %}
+
+<section class="c-sam-collection">
+  <div class="c-section-heading">
+    <h3 class="c-section-heading__title">Chapters</h3>
+    <span class="c-section-heading__meta">{{ chapters | size }} chapter{% if chapters.size != 1 %}s{% endif %} · ongoing</span>
+  </div>
+
+  <div class="c-post-grid">
+    {% for chapter in chapters %}
+    <a class="c-post" href="{{ chapter.url | prepend: site.baseurl }}">
+      <div class="c-post__image-wrap">
+        {% if chapter.image %}
+        <div class="c-post__image" style="background-image: url('{{ "/images/" | prepend: site.baseurl | append: chapter.image }}')"></div>
+        {% else %}
+        <div class="c-post__placeholder">Chapter {{ chapter.series_order | default: forloop.index }}</div>
+        {% endif %}
+      </div>
+      <div class="c-post__body">
+        <div class="c-post__eyebrow">Chapter {{ chapter.series_order | default: forloop.index }}</div>
+        <h3 class="c-post__title">{{ chapter.title | remove: " — Sam Bell · Moon AU" }}</h3>
+        {% if chapter.summary %}<p class="c-post__summary">{{ chapter.summary }}</p>{% endif %}
+        <div class="c-post__meta">
+          <span>{{ chapter.date | date: '%Y, %b %d' }}</span>
+          {% capture words %}{{ chapter.content | number_of_words }}{% endcapture %}
+          {% unless words contains "-" %}
+          <span>{{ words | plus: 250 | divided_by: 250 | append: " min read" }}</span>
+          {% endunless %}
+        </div>
+      </div>
+    </a>
+    {% endfor %}
+  </div>
+</section>


### PR DESCRIPTION
## What this PR does

Adds a generic **series** concept so multi-chapter stories collapse into a single collection card on category-filtered tabs, while still listing each chapter individually in publish order on the homepage default. Designed to apply to any future series, not just Sam Bell · Moon AU.

## Behavior by surface

| Where | Before | After |
| --- | --- | --- |
| Homepage default (About / All Stories) | Each chapter as its own card | **Same** — each chapter as its own card, publish order |
| Homepage AU Story tab | Each chapter as its own card | One **series card** instead, plus any non-series AU posts |
| Sam page card "Sam Bell · Moon AU" | Linked to `/?cat=AU+Story` (filter view) | Links to `/series/sam-bell-moon-au/` (series landing page) |
| New: `/series/sam-bell-moon-au/` | (didn't exist) | Series hero + intro + ordered chapter list |

## How a series is declared

Two fields in the post's front matter:

```yaml
series: "Sam Bell · Moon AU"
series_order: 1
```

Posts sharing the same `series:` value group together. `series_order` controls chapter ordering inside the series page. No code changes needed for new series — just add a `/series/<slug>/index.html` landing page modeled on this PR's.

## Files changed

- `_posts/2026-05-01-sam-bell-moon-au-chapter-1-departure.md` — add `series:` + `series_order: 1`
- `_posts/2026-05-01-sam-bell-moon-au-chapter-2-awakening.md` — add `series:` + `series_order: 2`
- `series/sam-bell-moon-au/index.html` — **new** series landing page
- `index.html` — render series cards (one per unique series) before chapter cards in the post grid; cards carry `data-card-type` and `data-series` for the JS filter
- `js/main.js` — `applyCategoryFilter` rewritten:
  - `all`: show chapter cards only
  - specific category: show series cards in that category plus non-series chapters in that category
- `sam/index.html` — AU Story card href updated

## A quick sanity-check after merge

- Homepage default: still shows both chapters as individual cards. ✓
- Click AU Story tab: shows ONE *Sam Bell · Moon AU · Series* card; the two chapter cards are hidden. ✓
- Click that series card: opens `/series/sam-bell-moon-au/` in a new tab — hero, intro, two chapter cards (Chapter 1 first). ✓
- From Sam page: same destination. ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCYAvpnGLWvxwEusuuikKA)_