### PR TITLE
Series page lights up AU Story tab, not Sam

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,8 +1,15 @@
 <header class="c-topbar">
   <div class="o-container c-topbar__inner">
-    {% comment %} About is now the home page; HOME tab removed. {% endcomment %}
+    {% comment %}
+      About is now the home page; HOME tab removed.
+      Pages can override the active tab by setting `nav_active` in their
+      front matter — e.g. a series landing page declares its category so
+      the corresponding filter tab lights up instead of Sam getting a
+      false-positive substring match on "/sam-bell-..." URLs.
+    {% endcomment %}
     {% assign nav_active = '' %}
-    {% if page.url contains '/sam' %}{% assign nav_active = 'sam' %}
+    {% if page.nav_active %}{% assign nav_active = page.nav_active %}
+    {% elsif page.url contains '/sam/' %}{% assign nav_active = 'sam' %}
     {% elsif page.url == '/' or page.url == '/index.html' or page.url == '/about/' %}{% assign nav_active = 'about' %}
     {% endif %}
 
@@ -17,16 +24,16 @@
         <li class="c-nav__item c-nav__item--link{% if nav_active == 'about' %} is-active{% endif %}">
           <a href="{{site.baseurl}}/">About</a>
         </li>
-        <li class="c-nav__item c-item_post" data-filter="Daily">
+        <li class="c-nav__item c-item_post{% if nav_active == 'Daily' %} is-active{% endif %}" data-filter="Daily">
           <a href="{{site.baseurl}}/?cat=Daily">Daily</a>
         </li>
-        <li class="c-nav__item c-item_post" data-filter="Novel">
+        <li class="c-nav__item c-item_post{% if nav_active == 'Novel' %} is-active{% endif %}" data-filter="Novel">
           <a href="{{site.baseurl}}/?cat=Novel">Novel</a>
         </li>
-        <li class="c-nav__item c-item_post" data-filter="AU Story">
+        <li class="c-nav__item c-item_post{% if nav_active == 'AU Story' %} is-active{% endif %}" data-filter="AU Story">
           <a href="{{site.baseurl}}/?cat=AU+Story">AU Story</a>
         </li>
-        <li class="c-nav__item c-item_post" data-filter="Lyrics">
+        <li class="c-nav__item c-item_post{% if nav_active == 'Lyrics' %} is-active{% endif %}" data-filter="Lyrics">
           <a href="{{site.baseurl}}/?cat=Lyrics">Lyrics</a>
         </li>
         <li class="c-nav__item c-item_images">

--- a/series/sam-bell-moon-au/index.html
+++ b/series/sam-bell-moon-au/index.html
@@ -2,6 +2,7 @@
 layout: home
 title: "Sam Bell · Moon AU"
 permalink: /series/sam-bell-moon-au/
+nav_active: "AU Story"
 ---
 
 <section class="c-hero">


### PR DESCRIPTION
## Why

On `/series/sam-bell-moon-au/`, the SAM tab was being highlighted instead of AU Story. The header's check was

```liquid
{% if page.url contains '/sam' %}
```

which substring-matches the `sam` in `sam-bell-moon-au` — false positive.

## Fix

1. Tighten the Sam match to `'/sam/'` (with trailing slash) so it only catches actual Sam pages (`/sam/`, `/sam/many-faces/`).
2. Let any page override the active tab via front matter:
   ```yaml
   nav_active: "AU Story"
   ```
   The series page declares this so the AU STORY tab lights up when you're on it. Generalised — any future page can opt into any nav state via the same field.
3. Extend the filter tabs (Daily / Novel / AU Story / Lyrics) to honour `nav_active` via Liquid `is-active`, parallel to how About and Sam already worked.

## After merging

- `/series/sam-bell-moon-au/` → **AU STORY** tab is highlighted ✓
- `/sam/`, `/sam/many-faces/` → **SAM** tab still highlighted ✓
- Homepage with `?cat=...` → JS still drives the active state at runtime, unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCYAvpnGLWvxwEusuuikKA)_