### PR TITLE
Restore Winter in Wonderland title; reformat about prose as fact blocks

### DIFF
--- a/_sass/5-components/_hero.scss
+++ b/_sass/5-components/_hero.scss
@@ -236,7 +236,7 @@
 
 /* ===== About page prose ===== */
 .c-about {
-  max-width: 640px;
+  max-width: 760px;
   margin: 0 auto 80px;
   padding: 0 8px;
   font-size: 16px;
@@ -245,12 +245,55 @@
   p { margin: 0 0 20px; }
   .c-about__lede {
     font-family: $heading-font-family;
-    font-size: 19px;
+    font-size: 21px;
     font-style: italic;
     color: $ink;
     line-height: 1.6;
-    margin-bottom: 28px;
+    margin-bottom: 36px;
+    text-align: center;
   }
+}
+
+/* ----- Three small fact blocks under the about lede ----- */
+.c-about__facts {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 36px;
+  list-style: none;
+  margin: 0;
+  padding: 32px 0 0;
+  border-top: 1px solid $line;
+
+  li {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    text-align: center;
+  }
+  .c-about__facts-label {
+    font-family: $heading-font-family;
+    font-size: 11px;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: $accent;
+  }
+  .c-about__facts-text {
+    font-family: $heading-font-family;
+    font-style: italic;
+    font-size: 15px;
+    line-height: 1.55;
+    color: $ink-soft;
+  }
+}
+
+@media only screen and (max-width: 720px) {
+  .c-about__facts {
+    grid-template-columns: 1fr;
+    gap: 22px;
+    padding-top: 26px;
+    li { text-align: left; }
+  }
+  .c-about .c-about__lede { font-size: 18px; }
 }
 
 /* ===== Section heading used above lists ===== */

--- a/index.html
+++ b/index.html
@@ -35,11 +35,11 @@ layout: home
   </a>
   {% endif %}
 
-  <div class="c-hero__eyebrow">About</div>
-  <h1 class="c-hero__title">Hi, I'm <em>Winter Sun</em></h1>
+  <div class="c-hero__eyebrow">A Personal Blog</div>
+  <h1 class="c-hero__title">Winter in <em>Wonderland</em></h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
-    <span class="c-hero__byline-text">冬璇 · {{ site.author-job }}</span>
+    <span class="c-hero__byline-text">by 冬璇 · Winter Sun</span>
     <span class="c-hero__byline-rule"></span>
   </div>
 
@@ -48,6 +48,8 @@ layout: home
     {{ site.about-author | strip_html }}
     <span class="c-hero__quote c-hero__quote--end">&rdquo;</span>
   </p>
+
+  <div class="c-hero__role">{{ site.author-job }}</div>
 
   <div class="c-hero__socials">
     {% if site.author-email %}<a href="{{site.baseurl}}/contact/">Contact</a>{% endif %}
@@ -63,10 +65,21 @@ layout: home
     daily notes, novels and AU stories I've written, lyric translations,
     and pictures I've drawn or fallen in love with.
   </p>
-  <p>
-    I write mostly in Chinese, sometimes in English, occasionally side by side.
-    I make things slowly. Thanks for stopping by.
-  </p>
+
+  <ul class="c-about__facts">
+    <li>
+      <span class="c-about__facts-label">Language</span>
+      <span class="c-about__facts-text">Chinese, sometimes English — occasionally side by side.</span>
+    </li>
+    <li>
+      <span class="c-about__facts-label">Pace</span>
+      <span class="c-about__facts-text">Made slowly, with care.</span>
+    </li>
+    <li>
+      <span class="c-about__facts-label">Note</span>
+      <span class="c-about__facts-text">Thanks for stopping by.</span>
+    </li>
+  </ul>
 </article>
 
 <section class="c-hero c-hero--filter" data-hero-id="Daily">


### PR DESCRIPTION
## Summary

Two corrections to the About-as-homepage merge from yesterday:

**1. Restore "Winter in Wonderland" as the big title**
The previous "Hi, I'm Winter Sun" worked on the standalone About page but lost the site's identity at the front door. Bring back:
- Eyebrow: A Personal Blog
- Title: **Winter in *Wonderland***
- Byline (small, between rules): by 冬璇 · Winter Sun
- Quote: existing tagline
- Role pill: TRANSLATOR / ROMANTIC / DREAMER
- Socials: Contact / Weibo / Bilibili / Red Book

**2. Replace the second prose paragraph with three fact blocks**
The "I write mostly in Chinese..." paragraph felt prosaic next to the lyrical lede. Reformatted as a 3-column strip with small eyebrows + one-line italic phrases:

| LANGUAGE | PACE | NOTE |
|---|---|---|
| Chinese, sometimes English — occasionally side by side. | Made slowly, with care. | Thanks for stopping by. |

Separated from the lede by a hairline. Stacks to a single column on mobile.

## Test plan
- [ ] Homepage hero reads "Winter in Wonderland" with "by 冬璇 · Winter Sun" below
- [ ] About prose shows lede + 3 fact blocks (no second paragraph)
- [ ] Mobile (≤720px) — fact blocks stack vertically, left-aligned

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_