### PR TITLE
Slim the homepage: drop hero socials and About prose

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,37 +50,7 @@ layout: home
   </p>
 
   <div class="c-hero__role">{{ site.author-job }}</div>
-
-  <div class="c-hero__socials">
-    {% if site.author-email %}<a href="{{site.baseurl}}/contact/">Contact</a>{% endif %}
-    {% if site.author-weibo %}<a href="{{site.author-weibo}}" target="_blank" rel="noopener">Weibo</a>{% endif %}
-    {% if site.author-bilibili %}<a href="{{site.author-bilibili}}" target="_blank" rel="noopener">Bilibili</a>{% endif %}
-    {% if site.author-redbook %}<a href="{{site.author-redbook}}" target="_blank" rel="noopener">Red Book</a>{% endif %}
-  </div>
 </section>
-
-<article class="c-about" data-hero-id="all">
-  <p class="c-about__lede">
-    This is a quiet corner of the internet where I keep what matters to me —
-    daily notes, novels and AU stories I've written, lyric translations,
-    and pictures I've drawn or fallen in love with.
-  </p>
-
-  <ul class="c-about__facts">
-    <li>
-      <span class="c-about__facts-label">Language</span>
-      <span class="c-about__facts-text">Chinese, sometimes English — occasionally side by side.</span>
-    </li>
-    <li>
-      <span class="c-about__facts-label">Pace</span>
-      <span class="c-about__facts-text">Made slowly, with care.</span>
-    </li>
-    <li>
-      <span class="c-about__facts-label">Note</span>
-      <span class="c-about__facts-text">Thanks for stopping by.</span>
-    </li>
-  </ul>
-</article>
 
 <section class="c-hero c-hero--filter" data-hero-id="Daily">
   {% if site.author-image %}


### PR DESCRIPTION
## Summary

Homepage felt stacked after the About merge. Trim aggressively:

- **Drop hero socials row** (Contact / Weibo / Bilibili / Red Book) — the footer already carries the same links, no need for a duplicate inside the hero.
- **Drop the entire About prose section** (lede paragraph + 3 fact blocks). The eyebrow, title, byline, italic quote, and role pill in the hero already say "this is who I am, this is where you are"; re-stating it in prose felt repetitive.

What stays:
- Eyebrow: A Personal Blog
- Title: **Winter in *Wonderland***
- Byline: by 冬璇 · Winter Sun
- Quote: existing tagline
- Role pill: TRANSLATOR / ROMANTIC / DREAMER
- → All Stories grid

Hero now sits on roughly one screen and posts come up immediately after, restoring the magazine-front-page feel.

## Test plan
- [ ] Homepage hero fits in approximately one viewport on desktop
- [ ] Post grid starts right after the hero — no extra prose
- [ ] Footer still has Weibo / Bilibili / Red Book / Email

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_