### PR TITLE
Say Hello cards: describe what's shared on each platform

### DIFF
--- a/_pages/contact/index.html
+++ b/_pages/contact/index.html
@@ -42,7 +42,7 @@ permalink: /contact/
       <a href="{{site.author-redbook}}" target="_blank" rel="noopener" class="c-hello__card">
         <span class="c-hello__card-eyebrow">Red Book</span>
         <span class="c-hello__card-title">小红书</span>
-        <span class="c-hello__card-cta">Open in new tab ↗</span>
+        <span class="c-hello__card-cta">Sam 的每日切片 · 我爱的人和事 ↗</span>
       </a>
     </li>
     {% endif %}
@@ -51,7 +51,7 @@ permalink: /contact/
       <a href="{{site.author-weibo}}" target="_blank" rel="noopener" class="c-hello__card">
         <span class="c-hello__card-eyebrow">Weibo</span>
         <span class="c-hello__card-title">微博</span>
-        <span class="c-hello__card-cta">Open in new tab ↗</span>
+        <span class="c-hello__card-cta">随手记下我喜欢的瞬间 ↗</span>
       </a>
     </li>
     {% endif %}
@@ -60,7 +60,7 @@ permalink: /contact/
       <a href="{{site.author-bilibili}}" target="_blank" rel="noopener" class="c-hello__card">
         <span class="c-hello__card-eyebrow">Bilibili</span>
         <span class="c-hello__card-title">B 站</span>
-        <span class="c-hello__card-cta">Open in new tab ↗</span>
+        <span class="c-hello__card-cta">看过、收藏、想反复看的视频 ↗</span>
       </a>
     </li>
     {% endif %}


### PR DESCRIPTION
## Summary

The three social cards on the Say Hello page (Red Book / Weibo / Bilibili) all said the same generic "Open in new tab ↗" — that read like a contact list rather than channels worth visiting. Replace each with a short line that hints at *what gets shared there*:

- **Red Book** → Sam 的每日切片 · 我爱的人和事 ↗
- **Weibo** → 随手记下我喜欢的瞬间 ↗
- **Bilibili** → 看过、收藏、想反复看的视频 ↗

Email card keeps "Use the form below ↓" since that one really is functional contact, not a feed.

## Test plan
- [ ] /contact/ shows the three new descriptions on the Red Book / Weibo / Bilibili cards
- [ ] Email card still says "Use the form below ↓"
- [ ] Each card still opens the right destination in a new tab on click

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_