### PR TITLE
Tune Weibo & Bilibili card copy on the Say Hello page

### DIFF
--- a/_pages/contact/index.html
+++ b/_pages/contact/index.html
@@ -60,7 +60,7 @@ permalink: /contact/
       <a href="{{site.author-bilibili}}" target="_blank" rel="noopener" class="c-hello__card">
         <span class="c-hello__card-eyebrow">Bilibili</span>
         <span class="c-hello__card-title">B 站</span>
-        <span class="c-hello__card-cta">小红书发过的视频 · 这里同步 ↗</span>
+        <span class="c-hello__card-cta">视频自留地 · 也同步小红书 ↗</span>
       </a>
     </li>
     {% endif %}

--- a/_pages/contact/index.html
+++ b/_pages/contact/index.html
@@ -51,7 +51,7 @@ permalink: /contact/
       <a href="{{site.author-weibo}}" target="_blank" rel="noopener" class="c-hello__card">
         <span class="c-hello__card-eyebrow">Weibo</span>
         <span class="c-hello__card-title">微博</span>
-        <span class="c-hello__card-cta">随手记下我喜欢的瞬间 ↗</span>
+        <span class="c-hello__card-cta">走近一点的我 · 日常的细碎 ↗</span>
       </a>
     </li>
     {% endif %}
@@ -60,7 +60,7 @@ permalink: /contact/
       <a href="{{site.author-bilibili}}" target="_blank" rel="noopener" class="c-hello__card">
         <span class="c-hello__card-eyebrow">Bilibili</span>
         <span class="c-hello__card-title">B 站</span>
-        <span class="c-hello__card-cta">看过、收藏、想反复看的视频 ↗</span>
+        <span class="c-hello__card-cta">小红书发过的视频 · 这里同步 ↗</span>
       </a>
     </li>
     {% endif %}


### PR DESCRIPTION
## Summary

Refine two of the Say Hello channel descriptions:

- **Weibo** → 走近一点的我 · 日常的细碎 ↗
  Frame Weibo as the more personal channel — closer to daily life, not just collected moments.
- **Bilibili** → 视频自留地 · 也同步小红书 ↗
  Bilibili holds its own video content too, not just Red Book mirrors — reframe so the platform's identity is video, with the sync as a secondary note.

Red Book and Email cards unchanged.

## Test plan
- [ ] /contact/ Weibo card reads "走近一点的我 · 日常的细碎"
- [ ] /contact/ Bilibili card reads "视频自留地 · 也同步小红书"

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY