### PR TITLE
Auto-scroll mobile nav so the active tab stays in view

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -95,7 +95,28 @@ $(document).ready(function () {
   function setActiveNav($item) {
     $('.c-nav__list > .c-nav__item').removeClass('is-active');
     $item.addClass('is-active');
+    scrollActiveNavIntoView();
   }
+
+  // On mobile the nav scrolls horizontally; bring the active tab into
+  // view so users don't see the list snap back to "About" after every
+  // navigation.
+  function scrollActiveNavIntoView() {
+    var nav = document.querySelector('.c-nav');
+    var active = document.querySelector('.c-nav__list > .c-nav__item.is-active');
+    if (!nav || !active) return;
+    if (nav.scrollWidth <= nav.clientWidth) return; // not scrollable
+    var target = Math.max(0, active.offsetLeft - 16);
+    if (typeof nav.scrollTo === 'function') {
+      nav.scrollTo({ left: target, behavior: 'smooth' });
+    } else {
+      nav.scrollLeft = target;
+    }
+  }
+
+  // Position on first load (e.g. landing on /sam/ should show Sam in
+  // view, not the leftmost About).
+  scrollActiveNavIntoView();
 
   // Cache the site title (last segment of the page title, or the
   // whole thing if there's no " · " separator).


### PR DESCRIPTION
## Summary

On mobile the topbar nav scrolls horizontally. Before, clicking a tab on the right (Sam, Say Hello, etc.) would navigate to the page, but the new page's nav re-rendered scrolled all the way back to the **left** — so the active tab was hidden off-screen and the topbar looked disconnected from where the reader actually was.

Add `scrollActiveNavIntoView()` that runs:
- Once on document ready (puts the right tab in view on first paint)
- Every time `setActiveNav()` flips the highlight (in-page filter taps)

It only acts when the nav is actually horizontally scrollable (`scrollWidth > clientWidth`), and uses smooth `scrollTo` when supported. The active tab lands ~16px from the nav's left edge in the typical case; for the last tab (Say Hello) the scroll naturally clamps so it stays visible at the right.

## Test plan
- [ ] Mobile: open `/sam/` directly — Sam tab is visible in the topbar without manual scrolling
- [ ] Mobile: open `/contact/` directly — Say Hello tab is visible
- [ ] Mobile: from `/sam/`, tap Sam-Hello-back-and-forth — nav scrolls to keep the active tab visible
- [ ] Desktop: nothing changes (nav doesn't overflow)

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_