### PR TITLE
Fix related-post links — prepend baseurl so they don't 404

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -35,9 +35,9 @@ layout: home
         {% for post in site.related_posts limit:4 %}
         {% if post.image %}
           <div class="c-recent__item">
-            <a class="c-recent__image" href="{{ post.url }}" style="background-image: url( {{"/images/" | prepend: site.baseurl | append: post.image}})"></a>
+            <a class="c-recent__image" href="{{ post.url | prepend: site.baseurl }}" style="background-image: url( {{"/images/" | prepend: site.baseurl | append: post.image}})"></a>
             <div class="c-recent__footer">
-              <h4><a href="{{ post.url }}">{{ post.title }}</a></h4>
+              <h4><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h4>
               <div class="c-recent__date">
                 <time datetime="{{ post.date | date_to_xmlschema }}">{{post.date | date: "%B %-d, %Y"}}</time>
               </div>


### PR DESCRIPTION
## Summary

Related-post links at the bottom of each article ("YOU MIGHT ALSO ENJOY") were using `{{ post.url }}` on its own, so they pointed at e.g. `/2026/05/01/sam-bell-...` instead of `/WinterSunBlog/2026/05/01/sam-bell-...` — breaking out of the project subpath and hitting GitHub's generic 404 every time.

Prepend `site.baseurl` on both the image link and the title link in `_layouts/post.html`.

## Test plan
- [ ] Open any post → scroll to bottom → click a "You might also enjoy" card → loads the right article (no 404)

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_