### PR TITLE
Restructure article-page bottom: separate related posts, tighten gap

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -27,29 +27,34 @@ layout: home
         </div>
       </header>
       {{page.content | markdownify}}
+    </div> <!-- /.c-wrap-content -->
 
-      <div class="c-recent-post">
-        {% if site.related_posts %}
-        <h4 class="c-recent__title">YOU MIGHT ALSO ENJOY</h4>
-        <div class="c-recent__box">
-        {% for post in site.related_posts limit:4 %}
-        {% if post.image %}
-          <div class="c-recent__item">
-            <a class="c-recent__image" href="{{ post.url | prepend: site.baseurl }}" style="background-image: url( {{"/images/" | prepend: site.baseurl | append: post.image}})"></a>
-            <div class="c-recent__footer">
-              <h4><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h4>
-              <div class="c-recent__date">
-                <time datetime="{{ post.date | date_to_xmlschema }}">{{post.date | date: "%B %-d, %Y"}}</time>
-              </div>
+    {% if site.related_posts %}
+    {% assign related_with_image = site.related_posts | where_exp: "p", "p.image" | slice: 0, 4 %}
+    {% if related_with_image.size > 0 %}
+    <section class="c-related">
+      <div class="c-section-heading">
+        <h3 class="c-section-heading__title">You Might Also Enjoy</h3>
+        <span class="c-section-heading__meta">picked from the archive</span>
+      </div>
+      <div class="c-post-grid c-post-grid--quad">
+        {% for post in related_with_image %}
+        <a class="c-post" href="{{ post.url | prepend: site.baseurl }}">
+          <div class="c-post__image-wrap">
+            <div class="c-post__image" style="background-image: url('{{ "/images/" | prepend: site.baseurl | append: post.image }}')"></div>
+          </div>
+          <div class="c-post__body">
+            {% if post.categories.size > 0 %}<div class="c-post__eyebrow">{{ post.categories | first }}</div>{% endif %}
+            <h3 class="c-post__title">{{ post.title }}</h3>
+            <div class="c-post__meta">
+              <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: '%Y, %b %d' }}</time>
             </div>
           </div>
-        {% else %}
-        {% endif %}
+        </a>
         {% endfor %}
-        {% endif %}
-        </div>
-       
-      </div> <!-- /.c-recent-post -->
-    </div> <!-- /.c-wrap-content -->
+      </div>
+    </section>
+    {% endif %}
+    {% endif %}
   </div> <!-- /.c-article__content -->
 </article> <!-- /.c-article-page -->

--- a/_sass/5-components/_content.scss
+++ b/_sass/5-components/_content.scss
@@ -5,7 +5,7 @@
 .c-content {
   position: relative;
   width: 100%;
-  padding-bottom: 80px;
+  padding-bottom: 48px;
 }
 
 .c-empty-state {

--- a/_sass/5-components/_index-post.scss
+++ b/_sass/5-components/_index-post.scss
@@ -218,6 +218,27 @@
 .c-post.is-hidden,
 .c-featured.is-hidden { display: none; }
 
+/* ----- Related posts at bottom of article (4 columns on desktop) ----- */
+.c-related {
+  margin-top: 56px;
+}
+
+.c-post-grid--quad {
+  grid-template-columns: repeat(4, 1fr);
+  gap: 28px 24px;
+  .c-post__image-wrap { aspect-ratio: 4 / 3; margin-bottom: 16px; }
+  .c-post__title { font-size: 18px; line-height: 1.25; margin-bottom: 8px; }
+  .c-post__eyebrow { font-size: 9px; letter-spacing: 0.22em; margin-bottom: 8px; }
+  .c-post__meta { font-size: 10px; letter-spacing: 0.12em; }
+}
+
+@media only screen and (max-width: 1100px) {
+  .c-post-grid--quad { grid-template-columns: repeat(2, 1fr); }
+}
+@media only screen and (max-width: 560px) {
+  .c-post-grid--quad { grid-template-columns: 1fr; }
+}
+
 /* ----- Feature card (e.g. New Year fireworks above the image grid) ----- */
 .c-feature-card {
   display: block;


### PR DESCRIPTION
## Summary

The "You might also enjoy" block at the bottom of every article was visually mashed into the same white card as the article body, then a big cream gap separated it from the footer. Restructure for cleaner rhythm:

**Layout**
- Move the related-posts block **out** of `.c-wrap-content` so the white article card ends cleanly and the cream page bg separates it from the section below.
- Replace the old `.c-recent-post` markup with the standard **`.c-post-grid`** + **`c-section-heading`** pattern used everywhere else on the site, so the related posts read as a distinct section, in the same visual language.

**Cards**
- New `.c-post-grid--quad` modifier: 4 columns on desktop, 2 on tablet, 1 on mobile.
- Each card uses 4:3 image, category eyebrow, smaller title (18px), date — same DNA as the homepage cards but a touch more compact.

**Spacing**
- Drop `.c-content` `padding-bottom` from 80px → 48px so there isn't a large cream expanse between the related-posts row and the footer.

## Test plan
- [ ] Open any post — article card ends cleanly, then cream gap, then "You Might Also Enjoy" section heading, then the 4-card grid
- [ ] On the related cards, click goes to the right post (already fixed in PR #64)
- [ ] Mobile (≤560px) — quad grid stacks to one column

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_