### PR TITLE
Wire A Single Shot AU cover image into Chapter 1

### DIFF
--- a/_posts/2026-05-02-a-single-shot-au-chapter-1-the-pit.md
+++ b/_posts/2026-05-02-a-single-shot-au-chapter-1-the-pit.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Chapter 1 · The Pit — A Single Shot AU"
 date: 2026-05-02
+image: a-single-shot-au.jpg
 tags: [Sam, AU, "A Single Shot", 中文]
 categories: ["AU Story"]
 series: "A Single Shot AU"


### PR DESCRIPTION
## Summary

- Adds `image: a-single-shot-au.jpg` to the Chapter 1 front matter so the cover image (already on main) actually renders.
- Activates the banner in three places: chapter page top banner, home-page series card thumbnail, and the series-page chapter grid.

## Test plan

- [ ] After merge, GitHub Pages rebuilds main
- [ ] `/series/a-single-shot-au/` shows Chapter 1 card with the cover image
- [ ] `/2026/05/02/a-single-shot-au-chapter-1-the-pit/` shows the banner at the top
- [ ] Home page (filter: AU Story) series card shows the cover image

https://claude.ai/code/session_01U7oTwK8GZtoxBfYkpLrnCy

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7oTwK8GZtoxBfYkpLrnCy)_