### PR TITLE
Indent article paragraphs 2em (段首空两格)

### DIFF
--- a/_sass/5-components/_article-page.scss
+++ b/_sass/5-components/_article-page.scss
@@ -10,6 +10,18 @@
 .c-wrap-content {
   padding: 20px;
   background-color: $paper;
+
+  // Chinese-style paragraph indentation: 段首空两格.
+  // Scoped to direct child paragraphs so blockquotes, lists, and code
+  // blocks aren't affected. Image-only paragraphs are reset so the
+  // image doesn't shift right.
+  > p {
+    text-indent: 2em;
+  }
+  > p:has(> img:only-child),
+  > p:has(> a > img:only-child) {
+    text-indent: 0;
+  }
 }
 
 .c-article__image {


### PR DESCRIPTION
## Summary

Standard Chinese typography for prose: **段首空两格**.

Apply `text-indent: 2em` to direct child `<p>` elements inside `.c-wrap-content` so:

- Body paragraphs get the indent (Chinese AND English — both look fine).
- Blockquotes, lists, and code blocks are scoped out (the rule only matches direct `> p` children, not nested `<p>` inside `<blockquote>` / `<li>`).
- Image-only paragraphs are reset via `:has(> img:only-child)` so an embedded image doesn't shift right by 2 characters.

Modern `:has()` support is broad (Chrome 105+, Safari 15.4+, Firefox 121+). On older browsers the image-only fallback won't apply — the image gets nudged ~2 chars right, which is mildly weird but not broken.

## Test plan
- [ ] Open a Chinese-text post — every body paragraph indents nicely
- [ ] Embedded images still align flush, not pushed right
- [ ] Blockquotes, lyric `<pre>` blocks, headings unaffected

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_