### PR TITLE
Indent every br-separated line, not just paragraph starts

### DIFF
--- a/_sass/5-components/_article-page.scss
+++ b/_sass/5-components/_article-page.scss
@@ -13,10 +13,13 @@
 
   // Chinese-style paragraph indentation: 段首空两格.
   // Scoped to direct child paragraphs so blockquotes, lists, and code
-  // blocks aren't affected. Image-only paragraphs are reset so the
-  // image doesn't shift right.
+  // blocks aren't affected. The `each-line` keyword also indents
+  // lines after a forced <br> break — a lot of posts use markdown
+  // trailing-space line breaks, so without it only the first line
+  // would indent.
   > p {
     text-indent: 2em;
+    text-indent: 2em each-line;
   }
   > p:has(> img:only-child),
   > p:has(> a > img:only-child) {


### PR DESCRIPTION
## Summary

The previous indent rule (`text-indent: 2em`) only nudged the **first line** of each `<p>`. A lot of the older posts use Markdown's *trailing-space line break* convention (which renders as `<br>`) instead of true blank-line paragraph breaks — so several "paragraphs" end up inside one `<p>`, and only the first sentence got the indent.

Add the **`each-line`** keyword:

```css
text-indent: 2em;
text-indent: 2em each-line;
```

`each-line` indents the first line of the block AND every line after a forced break (`<br>`), without affecting soft wraps from word-wrapping. Browser support: Chrome / Edge / Safari ≥ 16.4. Firefox doesn't support it yet — kept the plain `text-indent: 2em` as the first declaration so Firefox readers still get the basic first-line indent (no regression from PR #78).

## Test plan
- [ ] Open `/2023/06/20/where-the-story-ends/` (or any older post with markdown trailing-space line breaks) — every visible "paragraph" indents
- [ ] Posts that were already using true blank-line paragraph breaks still indent correctly
- [ ] Image-only paragraphs and code blocks still don't shift

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_