### PR TITLE
Tighten hero lede line-height (especially on mobile)

### DIFF
--- a/_sass/5-components/_hero.scss
+++ b/_sass/5-components/_hero.scss
@@ -146,7 +146,7 @@
   font-family: $heading-font-family;
   font-style: italic;
   font-size: 22px;
-  line-height: 1.55;
+  line-height: 1.4;
   color: $ink-soft;
   text-wrap: pretty;
 }
@@ -157,6 +157,7 @@
   font-style: italic;
   font-weight: 700;
   font-size: 1.7em;
+  line-height: 1; /* don't let the giant glyph blow up its line height */
   color: $accent-soft;
   vertical-align: -0.18em;
   user-select: none;
@@ -223,10 +224,11 @@
   .c-hero__byline-text { font-size: 13px; }
   .c-hero__lede {
     font-size: 17px;
+    line-height: 1.45;
     padding: 0 8px;
   }
   .c-hero__quote {
-    font-size: 40px;
+    font-size: 1.5em;
   }
   .c-hero__eyebrow {
     font-size: 11px;


### PR DESCRIPTION
## Summary

The two lines of "You found me. Why'd you have to wait to find me?" sat way too far apart on mobile.

**Root cause**: the `.c-hero__quote` glyph (font-size 1.7em) inherited the lede's line-height of 1.55, so each line containing a quote needed ~62px of vertical space even though the body text was only 26px. Both lines have a quote, so both got blown up.

**Fixes**:
- `.c-hero__quote` `line-height: 1` — the giant glyph stops dragging the surrounding line height up.
- `.c-hero__lede` `line-height: 1.55 → 1.4` (1.45 on mobile) for tighter, more poem-like spacing.
- Mobile quote nudged from a hard-coded 40px to `1.5em` so it scales with the lede font and keeps a nicer proportion.

Result on a 390-wide mobile: lede block went from **124px tall to 52px** — two lines with comfortable but not airy spacing.

## Test plan
- [ ] Mobile homepage: lede sits as two close lines, no big gap
- [ ] Desktop homepage: lede still readable (1.4 line-height looks balanced for one or two lines)
- [ ] Quotes still flank the text inline, not pushed to their own lines

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_