### PR TITLE
Add chapter nav, /archive/, redesigned 404, sticky TOC

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,38 +1,33 @@
 ---
 layout: home
-title: Page not found
+title: 404
 permalink: /404.html
 ---
 
-<style media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 60px;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
+<section class="c-hero">
+  {% if site.author-image %}
+  <a class="c-hero__portrait" href="{{site.baseurl}}/" aria-label="Home">
+    <img src="{{site.baseurl}}/images/{{site.author-image}}" alt="">
+  </a>
+  {% endif %}
 
-<div class="container">
-  <header class="c-header u-hide u-no-margin-bottom">
-    <div class="c-header__box">
-      <div class="c-search u-full-width">
-        <div class="c-search__box">
-          <label for="js-search-input" class="u-screen-reader-text">Search for Blog</label>
-          <input type="text" id="js-search-input" class="c-search__text" autocomplete="off" placeholder="Type to search...">
-          <div data-icon='ei-search' data-size='s'></div>
-        </div>
-        <ul id="js-results-container" class="c-search-results-list"></ul>
-      </div>
-    </div>
-  </header>
-  <h1>404</h1>
-  <p><strong>Page not found :(</strong></p>
-  <p>The requested page could not be found.</p>
-  <p><a href="{{site.baseurl}}/">Back to the bLog</a></p>
-</div>
+  <div class="c-hero__eyebrow">404 · Lost</div>
+  <h1 class="c-hero__title">Off the <em>Map</em></h1>
+  <div class="c-hero__byline">
+    <span class="c-hero__byline-rule"></span>
+    <span class="c-hero__byline-text">这一页似乎掉进了兔子洞</span>
+    <span class="c-hero__byline-rule"></span>
+  </div>
+
+  <p class="c-hero__lede">
+    <span class="c-hero__quote">&ldquo;</span>
+    Curiouser and curiouser! 你想找的页面不在这里——也许它从未存在过，也许它换了名字，也许它躲到月亮背面去了。
+    <span class="c-hero__quote c-hero__quote--end">&rdquo;</span>
+  </p>
+
+  <div class="c-hero__socials">
+    <a href="{{site.baseurl}}/">回家</a>
+    <a href="{{site.baseurl}}/archive/">翻翻归档</a>
+    <a href="{{site.baseurl}}/contact/">告诉我哪条链接坏了</a>
+  </div>
+</section>

--- a/_includes/main.scss
+++ b/_includes/main.scss
@@ -36,6 +36,7 @@
 @import '5-components/index-post';
 @import '5-components/sam';
 @import '5-components/hello';
+@import '5-components/extras';
 @import '5-components/article-page';
 @import '5-components/tags';
 @import '5-components/header';

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -16,6 +16,7 @@ layout: default
       {% if site.author-bilibili %}<a href="{{site.author-bilibili}}" target="_blank" rel="noopener">Bilibili</a>{% endif %}
       {% if site.author-redbook %}<a href="{{site.author-redbook}}" target="_blank" rel="noopener">Red Book</a>{% endif %}
       {% if site.author-email %}<a href="{{site.baseurl}}/contact/">Email</a>{% endif %}
+      <a href="{{site.baseurl}}/archive/">Archive</a>
     </div>
     <div class="c-footer__copy">
       {{site.time | date: '%Y'}} &copy; {{site.author-name}} · {{site.title}}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -29,6 +29,42 @@ layout: home
       {{page.content | markdownify}}
     </div> <!-- /.c-wrap-content -->
 
+    {% if page.series %}
+    {% assign series_posts = site.posts | where: "series", page.series | sort: "series_order" %}
+    {% assign cur_idx = -1 %}
+    {% for sp in series_posts %}{% if sp.url == page.url %}{% assign cur_idx = forloop.index0 %}{% endif %}{% endfor %}
+    {% if cur_idx >= 0 %}
+    {% assign last_idx = series_posts.size | minus: 1 %}
+    {% assign prev_idx = cur_idx | minus: 1 %}
+    {% assign next_idx = cur_idx | plus: 1 %}
+    {% assign prev_post = series_posts[prev_idx] %}
+    {% assign next_post = series_posts[next_idx] %}
+    <nav class="c-chapter-nav" aria-label="Chapter navigation">
+      <div class="c-chapter-nav__series">
+        Part of <a href="{{ site.baseurl }}/series/{{ page.series | slugify }}/">{{ page.series }}</a> · Chapter {{ page.series_order }} of {{ series_posts.size }}
+      </div>
+      <div class="c-chapter-nav__pair">
+        {% if cur_idx > 0 %}
+          <a class="c-chapter-nav__link c-chapter-nav__link--prev" href="{{ prev_post.url | prepend: site.baseurl }}">
+            <span class="c-chapter-nav__eyebrow">← Previous</span>
+            <span class="c-chapter-nav__title">{{ prev_post.title | split: " — " | first }}</span>
+          </a>
+        {% else %}
+          <span class="c-chapter-nav__placeholder"></span>
+        {% endif %}
+        {% if cur_idx < last_idx %}
+          <a class="c-chapter-nav__link c-chapter-nav__link--next" href="{{ next_post.url | prepend: site.baseurl }}">
+            <span class="c-chapter-nav__eyebrow">Next →</span>
+            <span class="c-chapter-nav__title">{{ next_post.title | split: " — " | first }}</span>
+          </a>
+        {% else %}
+          <span class="c-chapter-nav__placeholder"></span>
+        {% endif %}
+      </div>
+    </nav>
+    {% endif %}
+    {% endif %}
+
     {% if site.related_posts %}
     {% assign related_with_image = site.related_posts | where_exp: "p", "p.image" | slice: 0, 4 %}
     {% if related_with_image.size > 0 %}

--- a/_pages/archive/index.html
+++ b/_pages/archive/index.html
@@ -1,0 +1,42 @@
+---
+layout: home
+title: Archive
+permalink: /archive/
+nav_active: archive
+---
+
+<section class="c-hero c-hero--filter">
+  {% if site.author-image %}
+  <a class="c-hero__portrait" href="{{site.baseurl}}/" aria-label="Home">
+    <img src="{{site.baseurl}}/images/{{site.author-image}}" alt="{{site.author-name}}">
+  </a>
+  {% endif %}
+  <div class="c-hero__eyebrow">Archive</div>
+  <h1 class="c-hero__title">Down the <em>Years</em></h1>
+  <div class="c-hero__byline">
+    <span class="c-hero__byline-rule"></span>
+    <span class="c-hero__byline-text">每一篇都还在 · {{ site.posts.size }} stories so far</span>
+    <span class="c-hero__byline-rule"></span>
+  </div>
+</section>
+
+<section class="c-archive">
+  {% assign posts_by_year = site.posts | group_by_exp: "post", "post.date | date: '%Y'" %}
+  {% for year_group in posts_by_year %}
+  <div class="c-archive__year">
+    <div class="c-archive__heading">
+      <span class="c-archive__year-num">{{ year_group.name }}</span>
+      <span class="c-archive__year-meta">{{ year_group.items.size }} {% if year_group.items.size == 1 %}story{% else %}stories{% endif %}</span>
+    </div>
+    <ul class="c-archive__list">
+      {% for post in year_group.items %}
+      <li class="c-archive__item">
+        <span class="c-archive__date">{{ post.date | date: '%b %d' }}</span>
+        <a class="c-archive__title" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+        {% if post.categories.size > 0 %}<span class="c-archive__cat">{{ post.categories | first }}</span>{% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endfor %}
+</section>

--- a/_sass/5-components/_extras.scss
+++ b/_sass/5-components/_extras.scss
@@ -1,0 +1,238 @@
+/* ===============
+	CHAPTER NAV (prev / next within a series)
+=============== */
+
+.c-chapter-nav {
+  margin: 48px 0 16px;
+  text-align: center;
+}
+
+.c-chapter-nav__series {
+  font-family: $heading-font-family;
+  font-style: italic;
+  font-size: 13px;
+  color: $muted;
+  margin-bottom: 18px;
+  a { color: $accent; text-decoration: none; }
+  a:hover { color: $accent-dark; }
+}
+
+.c-chapter-nav__pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.c-chapter-nav__placeholder { display: block; }
+
+.c-chapter-nav__link {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 18px 22px;
+  border: 1px solid $line;
+  border-radius: 4px;
+  background-color: $paper;
+  text-decoration: none;
+  color: inherit;
+  transition: $global-transition;
+  &:hover {
+    border-color: $accent-soft;
+    transform: translateY(-2px);
+    box-shadow: 0 14px 28px -14px rgba(var(--rgb-shadow), 0.18);
+    .c-chapter-nav__title { color: $accent; }
+  }
+}
+
+.c-chapter-nav__link--prev { text-align: left; }
+.c-chapter-nav__link--next { text-align: right; }
+
+.c-chapter-nav__eyebrow {
+  font-family: $heading-font-family;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: $accent;
+}
+
+.c-chapter-nav__title {
+  font-family: $heading-font-family;
+  font-size: 17px;
+  font-weight: 700;
+  color: $ink;
+  line-height: 1.3;
+  transition: color $global-transition;
+}
+
+@media only screen and (max-width: 600px) {
+  .c-chapter-nav__pair { grid-template-columns: 1fr; }
+  .c-chapter-nav__link--prev,
+  .c-chapter-nav__link--next { text-align: left; }
+}
+
+
+/* ===============
+	ARCHIVE PAGE
+=============== */
+
+.c-archive {
+  max-width: 760px;
+  margin: 32px auto 80px;
+  padding: 0 8px;
+}
+
+.c-archive__year {
+  margin-bottom: 56px;
+}
+
+.c-archive__heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  border-bottom: 1px solid $line;
+  padding-bottom: 12px;
+  margin-bottom: 18px;
+}
+
+.c-archive__year-num {
+  font-family: $heading-font-family;
+  font-size: 32px;
+  font-weight: 700;
+  color: $ink;
+  letter-spacing: -0.01em;
+}
+
+.c-archive__year-meta {
+  font-family: $heading-font-family;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: $muted;
+}
+
+.c-archive__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c-archive__item {
+  display: grid;
+  grid-template-columns: 80px 1fr auto;
+  gap: 16px;
+  align-items: baseline;
+  padding: 10px 0;
+  border-bottom: 1px solid $line;
+  &:last-child { border-bottom: 0; }
+}
+
+.c-archive__date {
+  font-family: $heading-font-family;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: $muted;
+}
+
+.c-archive__title {
+  font-family: $heading-font-family;
+  font-size: 17px;
+  color: $ink;
+  text-decoration: none;
+  line-height: 1.4;
+  &:hover { color: $accent; }
+}
+
+.c-archive__cat {
+  font-family: $heading-font-family;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: $accent;
+  white-space: nowrap;
+}
+
+@media only screen and (max-width: 600px) {
+  .c-archive__item {
+    grid-template-columns: 64px 1fr;
+    gap: 10px;
+  }
+  .c-archive__cat {
+    grid-column: 2;
+    font-size: 9px;
+    margin-top: 2px;
+  }
+  .c-archive__year-num { font-size: 26px; }
+}
+
+
+/* ===============
+	STICKY TOC FOR CHAPTER POSTS
+=============== */
+
+.c-toc {
+  display: none;
+  font-family: $heading-font-family;
+}
+
+@media (min-width: 1320px) {
+  .c-toc {
+    display: block;
+    position: fixed;
+    top: 96px;
+    right: 24px;
+    width: 200px;
+    max-height: calc(100vh - 130px);
+    overflow-y: auto;
+    padding: 18px 18px 18px 0;
+    z-index: 30;
+  }
+}
+
+.c-toc__title {
+  font-style: italic;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: $accent;
+  font-size: 10px;
+  margin-bottom: 14px;
+  padding-left: 14px;
+}
+
+.c-toc__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c-toc__item { margin: 0; }
+
+.c-toc__item a {
+  display: block;
+  padding: 6px 0 6px 14px;
+  border-left: 1px solid $line;
+  font-size: 12px;
+  line-height: 1.45;
+  color: $muted;
+  text-decoration: none;
+  transition: color $global-transition, border-color $global-transition;
+  word-break: break-word;
+  &:hover {
+    color: $accent;
+    border-color: $accent-soft;
+  }
+  &.is-active {
+    color: $accent;
+    border-color: $accent;
+  }
+}
+
+.c-toc__item--h3 a {
+  padding-left: 22px;
+  font-size: 11px;
+  color: $muted-soft;
+}
+
+/* Hide the scrollbar nicely on TOC */
+.c-toc::-webkit-scrollbar { width: 4px; }
+.c-toc::-webkit-scrollbar-thumb { background: $line-strong; border-radius: 2px; }

--- a/js/main.js
+++ b/js/main.js
@@ -247,6 +247,50 @@ $(document).ready(function () {
   });
 
   /* =======================
+  // Sticky TOC for long chapter posts
+  ======================= */
+
+  (function buildArticleTOC() {
+    var article = document.querySelector('.c-wrap-content');
+    if (!article) return;
+    var headings = article.querySelectorAll('h2, h3');
+    if (headings.length < 3) return; // not worth a TOC
+
+    var toc = document.createElement('nav');
+    toc.className = 'c-toc';
+    toc.setAttribute('aria-label', '本章目录');
+    toc.innerHTML = '<div class="c-toc__title">本章</div><ol class="c-toc__list"></ol>';
+    var list = toc.querySelector('.c-toc__list');
+
+    headings.forEach(function (h, i) {
+      if (!h.id) h.id = 'toc-h-' + i;
+      var li = document.createElement('li');
+      li.className = 'c-toc__item c-toc__item--' + h.tagName.toLowerCase();
+      var a = document.createElement('a');
+      a.href = '#' + h.id;
+      a.textContent = h.textContent;
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+
+    document.body.appendChild(toc);
+
+    // Highlight current section as it scrolls past the top
+    if ('IntersectionObserver' in window) {
+      var observer = new IntersectionObserver(function (entries) {
+        entries.forEach(function (e) {
+          if (e.isIntersecting) {
+            list.querySelectorAll('a').forEach(function (a) { a.classList.remove('is-active'); });
+            var link = list.querySelector('a[href="#' + e.target.id + '"]');
+            if (link) link.classList.add('is-active');
+          }
+        });
+      }, { rootMargin: '-15% 0% -75% 0%', threshold: 0 });
+      headings.forEach(function (h) { observer.observe(h); });
+    }
+  })();
+
+  /* =======================
   // Theme toggle (light / dark)
   ======================= */
 


### PR DESCRIPTION
## Summary

Four reader-friendly additions in one PR.

### 1. Chapter prev / next on series posts
When a post has `series` + `series_order`, render a nav block under the article body:
- A small "Part of {series} · Chapter X of N" line linking back to the series page
- Two cards: **← Previous {chapter}** and **Next {chapter} →**
- Stacks to one column on small screens, hides whichever side doesn't exist (first / last chapter)

### 2. /archive/ — Down the Years
A new page that groups every post by year (`group_by_exp`) with a clean date / title / category list. Uses the standard hero pattern (eyebrow "Archive", title "Down the *Years*"). Linked from the footer as **Archive**.

### 3. 404 in the new hero style
Old `404.html` was the plain leftover template. Replaced with a proper `c-hero` block:
- `404 · Lost` eyebrow
- "Off the *Map*" title
- Bilingual Alice-flavoured quote: *"Curiouser and curiouser! 你想找的页面不在这里——也许它从未存在过, 也许它换了名字, 也许它躲到月亮背面去了。"*
- Three pill links: 回家 · 翻翻归档 · 告诉我哪条链接坏了

### 4. Sticky in-article TOC
`main.js` scans the article for `h2` / `h3` (only when there are 3+) and builds a fixed right-rail TOC at viewports ≥ 1320px. `IntersectionObserver` highlights the active section as the reader scrolls. Hidden on narrower screens so the column doesn't crowd the text — articles still read naturally without it.

All four share styles in a new `_sass/5-components/_extras.scss`.

## Test plan
- [ ] Open chapter 2 of an AU series → bottom shows series line + Previous (ch 1) + Next (ch 3) cards
- [ ] Chapter 4 (last) → only Previous card; chapter 1 (first) → only Next
- [ ] /archive/ — posts grouped by year, with category labels on the right
- [ ] Footer shows "Archive" link
- [ ] Visit a non-existent URL → new "Off the Map" 404 page
- [ ] On a long chapter post at desktop ≥ 1320px width — sticky TOC on the right with active section highlight

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_