### PR TITLE
Make TOC visible inline; merge Tags into Archive tab

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -40,8 +40,8 @@
         <li class="c-nav__item c-item_images">
           <a href="{{site.baseurl}}/?view=gallery">Gallery</a>
         </li>
-        <li class="c-nav__item c-item_tags">
-          <a href="{{site.baseurl}}/?view=tags">Tags</a>
+        <li class="c-nav__item c-nav__item--link{% if nav_active == 'archive' %} is-active{% endif %}">
+          <a href="{{site.baseurl}}/archive/">Archive</a>
         </li>
         <li class="c-nav__item c-nav__item--link{% if nav_active == 'sam' %} is-active{% endif %}">
           <a href="{{site.baseurl}}/sam/">Sam</a>

--- a/_pages/archive/index.html
+++ b/_pages/archive/index.html
@@ -15,12 +15,17 @@ nav_active: archive
   <h1 class="c-hero__title">Down the <em>Years</em></h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
-    <span class="c-hero__byline-text">每一篇都还在 · {{ site.posts.size }} stories so far</span>
+    <span class="c-hero__byline-text">{{ site.posts.size }} stories so far · 按时间，也按情绪</span>
     <span class="c-hero__byline-rule"></span>
   </div>
 </section>
 
 <section class="c-archive">
+  <div class="c-section-heading">
+    <h3 class="c-section-heading__title">By Year</h3>
+    <span class="c-section-heading__meta">a timeline</span>
+  </div>
+
   {% assign posts_by_year = site.posts | group_by_exp: "post", "post.date | date: '%Y'" %}
   {% for year_group in posts_by_year %}
   <div class="c-archive__year">
@@ -36,6 +41,38 @@ nav_active: archive
         {% if post.categories.size > 0 %}<span class="c-archive__cat">{{ post.categories | first }}</span>{% endif %}
       </li>
       {% endfor %}
+    </ul>
+  </div>
+  {% endfor %}
+
+  {% capture site_tags %}{% for tag in site.tags %}{{ tag | first }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
+  {% assign tag_words = site_tags | split:',' | sort %}
+
+  <div class="c-section-heading c-section-heading--spacer">
+    <h3 class="c-section-heading__title">By Mood — Tags</h3>
+    <span class="c-section-heading__meta">{{ tag_words.size }} threads</span>
+  </div>
+
+  <ul class="c-archive-tags">
+    {% for w in tag_words %}
+    <li><a href="#tag-{{ w | cgi_escape }}">{{ w }} <span>{{ site.tags[w].size }}</span></a></li>
+    {% endfor %}
+  </ul>
+
+  {% for w in tag_words %}
+  <div class="c-archive__year c-archive__tag-group" id="tag-{{ w | cgi_escape }}">
+    <div class="c-archive__heading">
+      <span class="c-archive__year-num">{{ w }}</span>
+      <span class="c-archive__year-meta">{{ site.tags[w].size }} {% if site.tags[w].size == 1 %}story{% else %}stories{% endif %}</span>
+    </div>
+    <ul class="c-archive__list">
+      {% for post in site.tags[w] %}{% if post.title %}
+      <li class="c-archive__item">
+        <span class="c-archive__date">{{ post.date | date: '%Y, %b %d' }}</span>
+        <a class="c-archive__title" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+        {% if post.categories.size > 0 %}<span class="c-archive__cat">{{ post.categories | first }}</span>{% endif %}
+      </li>
+      {% endif %}{% endfor %}
     </ul>
   </div>
   {% endfor %}

--- a/_sass/5-components/_extras.scss
+++ b/_sass/5-components/_extras.scss
@@ -165,28 +165,82 @@
   .c-archive__year-num { font-size: 26px; }
 }
 
+.c-section-heading--spacer {
+  margin-top: 80px;
+}
+
+/* Tag pill cloud — sits between the year list and the tag-grouped lists */
+.c-archive-tags {
+  list-style: none;
+  margin: 0 0 56px;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  li { margin: 0; }
+  a {
+    display: inline-block;
+    padding: 6px 14px;
+    font-family: $heading-font-family;
+    font-size: 13px;
+    color: $ink-soft;
+    background: $paper-warm;
+    border: 1px solid $line;
+    border-radius: 999px;
+    text-decoration: none;
+    transition: $global-transition;
+    span {
+      color: $accent;
+      font-style: italic;
+      font-size: 11px;
+      margin-left: 6px;
+    }
+    &:hover {
+      color: $accent;
+      border-color: $accent-soft;
+      transform: translateY(-1px);
+    }
+  }
+}
+
+.c-archive__tag-group { scroll-margin-top: 80px; }
+
 
 /* ===============
-	STICKY TOC FOR CHAPTER POSTS
+	ARCHIVE CTA AT BOTTOM OF HOME GRID
+=============== */
+
+.c-archive-cta {
+  text-align: center;
+  margin: 56px 0 16px;
+  font-family: $heading-font-family;
+  font-style: italic;
+  font-size: 16px;
+  a {
+    color: $ink-soft;
+    text-decoration: none;
+    border-bottom: 1px solid $line-strong;
+    padding-bottom: 4px;
+    transition: $global-transition;
+    &:hover {
+      color: $accent;
+      border-color: $accent-soft;
+    }
+  }
+}
+
+
+/* ===============
+	IN-ARTICLE TOC (本章目录)
 =============== */
 
 .c-toc {
-  display: none;
+  margin: 8px 0 32px;
+  padding: 18px 22px;
+  background: $paper-warm;
+  border: 1px solid $line;
+  border-radius: 4px;
   font-family: $heading-font-family;
-}
-
-@media (min-width: 1320px) {
-  .c-toc {
-    display: block;
-    position: fixed;
-    top: 96px;
-    right: 24px;
-    width: 200px;
-    max-height: calc(100vh - 130px);
-    overflow-y: auto;
-    padding: 18px 18px 18px 0;
-    z-index: 30;
-  }
 }
 
 .c-toc__title {
@@ -194,45 +248,65 @@
   letter-spacing: 0.22em;
   text-transform: uppercase;
   color: $accent;
-  font-size: 10px;
+  font-size: 11px;
   margin-bottom: 14px;
-  padding-left: 14px;
 }
 
 .c-toc__list {
   list-style: none;
   margin: 0;
   padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 6px 18px;
 }
 
 .c-toc__item { margin: 0; }
 
 .c-toc__item a {
-  display: block;
-  padding: 6px 0 6px 14px;
-  border-left: 1px solid $line;
-  font-size: 12px;
-  line-height: 1.45;
-  color: $muted;
+  display: inline-block;
+  padding: 4px 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: $ink-soft;
   text-decoration: none;
-  transition: color $global-transition, border-color $global-transition;
-  word-break: break-word;
-  &:hover {
-    color: $accent;
-    border-color: $accent-soft;
-  }
+  transition: color $global-transition;
+  &:hover { color: $accent; }
   &.is-active {
     color: $accent;
-    border-color: $accent;
+    font-weight: 600;
   }
 }
 
 .c-toc__item--h3 a {
-  padding-left: 22px;
-  font-size: 11px;
-  color: $muted-soft;
+  padding-left: 14px;
+  font-size: 13px;
+  color: $muted;
 }
 
-/* Hide the scrollbar nicely on TOC */
-.c-toc::-webkit-scrollbar { width: 4px; }
-.c-toc::-webkit-scrollbar-thumb { background: $line-strong; border-radius: 2px; }
+/* On large desktops, also offer a sticky column on the right */
+@media (min-width: 1340px) {
+  .c-toc {
+    position: sticky;
+    top: 96px;
+    float: right;
+    margin: 0 0 24px 32px;
+    width: 220px;
+    padding: 16px 18px;
+  }
+  .c-toc__list {
+    display: block;
+  }
+  .c-toc__item a {
+    display: block;
+    padding: 6px 0 6px 12px;
+    border-left: 1px solid $line;
+    font-size: 12px;
+    &:hover { border-color: $accent-soft; }
+    &.is-active { border-color: $accent; }
+  }
+  .c-toc__item--h3 a {
+    padding-left: 22px;
+    font-size: 11px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@ layout: home
     var active = 'all';
     if (p.get('cat')) active = p.get('cat');
     else if (p.get('view') === 'gallery') active = 'gallery';
-    else if (p.get('view') === 'tags') active = 'tags';
     document.documentElement.setAttribute('data-hero-active', active);
 
     // Reflect the active filter in the browser tab title
@@ -18,8 +17,7 @@ layout: home
       'Novel': 'Novel',
       'AU Story': 'AU Story',
       'Lyrics': 'Lyrics',
-      'gallery': 'Gallery',
-      'tags': 'Tags'
+      'gallery': 'Gallery'
     };
     if (labels[active]) {
       document.title = labels[active] + ' · {{ site.title | escape }}';
@@ -127,21 +125,6 @@ layout: home
   </div>
 </section>
 
-<section class="c-hero c-hero--filter" data-hero-id="tags">
-  {% if site.author-image %}
-  <a class="c-hero__portrait" href="{{site.baseurl}}/" aria-label="Home">
-    <img src="{{site.baseurl}}/images/{{site.author-image}}" alt="{{site.author-name}}">
-  </a>
-  {% endif %}
-  <div class="c-hero__eyebrow">Tags</div>
-  <h1 class="c-hero__title">By <em>Mood</em></h1>
-  <div class="c-hero__byline">
-    <span class="c-hero__byline-rule"></span>
-    <span class="c-hero__byline-text">按主题与情绪，重新走一遍这里的每一篇</span>
-    <span class="c-hero__byline-rule"></span>
-  </div>
-</section>
-
 <div class="c-posts o-opacity">
   {% if site.posts.size > 0 %}
 
@@ -207,6 +190,10 @@ layout: home
     {% endfor %}
   </div>
 
+  <p class="c-archive-cta">
+    <a href="{{site.baseurl}}/archive/">Browse the full archive ↓</a>
+  </p>
+
   <div class="c-empty-state" data-empty hidden>
     <p class="c-empty-state__title">Nothing filed here yet.</p>
     <p class="c-empty-state__hint">This category is waiting for its first story.</p>
@@ -218,5 +205,4 @@ layout: home
 </div>
 
 {% include categories.html %}
-{% include blog-tags.html %}
 {% include image-show.html %}

--- a/js/main.js
+++ b/js/main.js
@@ -41,7 +41,7 @@ $(document).ready(function () {
 
   function showPostsView() {
     $('.c-posts').show().addClass('o-opacity');
-    $('.c-categories, .c-blog-tags, .c-show-images').hide().removeClass('o-opacity');
+    $('.c-categories, .c-show-images').hide().removeClass('o-opacity');
   }
 
   function applyCategoryFilter(filter) {
@@ -84,12 +84,7 @@ $(document).ready(function () {
 
   function showGallery() {
     $('.c-show-images').show().addClass('o-opacity');
-    $('.c-posts, .c-categories, .c-blog-tags').hide().removeClass('o-opacity');
-  }
-
-  function showTags() {
-    $('.c-blog-tags').show().addClass('o-opacity');
-    $('.c-posts, .c-categories, .c-show-images').hide().removeClass('o-opacity');
+    $('.c-posts, .c-categories').hide().removeClass('o-opacity');
   }
 
   function setActiveNav($item) {
@@ -131,8 +126,7 @@ $(document).ready(function () {
     'Novel': 'Novel',
     'AU Story': 'AU Story',
     'Lyrics': 'Lyrics',
-    'gallery': 'Gallery',
-    'tags': 'Tags'
+    'gallery': 'Gallery'
   };
 
   function setActiveHero(name) {
@@ -168,12 +162,6 @@ $(document).ready(function () {
       if (window.history && window.history.replaceState) {
         window.history.replaceState(null, '', BASEURL + '/?view=gallery');
       }
-    } else if ($this.hasClass('c-item_tags')) {
-      showTags();
-      setActiveHero('tags');
-      if (window.history && window.history.replaceState) {
-        window.history.replaceState(null, '', BASEURL + '/?view=tags');
-      }
     }
 
     if ($('main.c-content').length && window.scrollY > 200) {
@@ -196,9 +184,6 @@ $(document).ready(function () {
     } else if (view === 'gallery') {
       setActiveNav($('.c-nav__list > .c-item_images'));
       showGallery();
-    } else if (view === 'tags') {
-      setActiveNav($('.c-nav__list > .c-item_tags'));
-      showTags();
     }
   }
 
@@ -247,7 +232,7 @@ $(document).ready(function () {
   });
 
   /* =======================
-  // Sticky TOC for long chapter posts
+  // In-article TOC for long chapter posts
   ======================= */
 
   (function buildArticleTOC() {
@@ -259,7 +244,7 @@ $(document).ready(function () {
     var toc = document.createElement('nav');
     toc.className = 'c-toc';
     toc.setAttribute('aria-label', '本章目录');
-    toc.innerHTML = '<div class="c-toc__title">本章</div><ol class="c-toc__list"></ol>';
+    toc.innerHTML = '<div class="c-toc__title">本章目录</div><ol class="c-toc__list"></ol>';
     var list = toc.querySelector('.c-toc__list');
 
     headings.forEach(function (h, i) {
@@ -273,7 +258,13 @@ $(document).ready(function () {
       list.appendChild(li);
     });
 
-    document.body.appendChild(toc);
+    // Insert at the top of the article body — right after the header.
+    var header = article.querySelector('.c-article__header');
+    if (header && header.nextSibling) {
+      article.insertBefore(toc, header.nextSibling);
+    } else {
+      article.insertBefore(toc, article.firstChild);
+    }
 
     // Highlight current section as it scrolls past the top
     if ('IntersectionObserver' in window) {


### PR DESCRIPTION
## Summary

Three follow-ups from the "I couldn't find any of these" feedback:

**1. In-article TOC — now visible everywhere**
Was only showing on viewports ≥ 1320px (too narrow a window to test in). Move it inline to the **top of the article body** (right after the title/date header) as a compact wrap-grid of section links. On wide desktops (≥ 1340px), CSS lifts it into a sticky right rail; everywhere else it sits at the article top.

**2. Archive replaces Tags as a tab**
- Old "Tags" tab pointed at `?view=tags` and surfaced a hidden div on the homepage. Replace with an **Archive** tab linking to `/archive/`.
- The archive page now contains both sections:
  - **By Year** — timeline grouping (existing)
  - **By Mood — Tags** — the tag pill cloud + per-tag post lists, migrated from `blog-tags.html`
- Drop the `blog-tags.html` include from the homepage and the hidden `data-hero-id="tags"` block; clean up the JS / inline-script paths that referenced `view=tags`.

**3. Bonus surface for Archive**
A *"Browse the full archive ↓"* line under the All Stories grid on the homepage, so readers who scroll past every post still get the prompt to keep going.

## Test plan
- [ ] Open any chapter post — TOC sits at top, lists sub-headings, click jumps to section
- [ ] Click "Archive" tab — landing shows years first, then "By Mood — Tags" section with pill cloud + per-tag lists
- [ ] Click a tag pill in the cloud — page scrolls to that tag's group below
- [ ] Footer also still has the Archive link as a backup

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_