### PR TITLE
Archive page: sub-tabs (Year/Mood) + per-tag panel switching

### DIFF
--- a/_pages/archive/index.html
+++ b/_pages/archive/index.html
@@ -21,59 +21,68 @@ nav_active: archive
 </section>
 
 <section class="c-archive">
-  <div class="c-section-heading">
-    <h3 class="c-section-heading__title">By Year</h3>
-    <span class="c-section-heading__meta">a timeline</span>
+
+  <div class="c-archive-tabs" role="tablist">
+    <button class="c-archive-tab is-active" type="button" role="tab" data-archive-view="year" aria-selected="true">By Year</button>
+    <button class="c-archive-tab" type="button" role="tab" data-archive-view="mood" aria-selected="false">By Mood</button>
   </div>
 
-  {% assign posts_by_year = site.posts | group_by_exp: "post", "post.date | date: '%Y'" %}
-  {% for year_group in posts_by_year %}
-  <div class="c-archive__year">
-    <div class="c-archive__heading">
-      <span class="c-archive__year-num">{{ year_group.name }}</span>
-      <span class="c-archive__year-meta">{{ year_group.items.size }} {% if year_group.items.size == 1 %}story{% else %}stories{% endif %}</span>
+  {% comment %} ===== BY YEAR ===== {% endcomment %}
+  <div class="c-archive-panel" data-archive-panel="year">
+    {% assign posts_by_year = site.posts | group_by_exp: "post", "post.date | date: '%Y'" %}
+    {% for year_group in posts_by_year %}
+    <div class="c-archive__year">
+      <div class="c-archive__heading">
+        <span class="c-archive__year-num">{{ year_group.name }}</span>
+        <span class="c-archive__year-meta">{{ year_group.items.size }} {% if year_group.items.size == 1 %}story{% else %}stories{% endif %}</span>
+      </div>
+      <ul class="c-archive__list">
+        {% for post in year_group.items %}
+        <li class="c-archive__item">
+          <span class="c-archive__date">{{ post.date | date: '%b %d' }}</span>
+          <a class="c-archive__title" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+          {% if post.categories.size > 0 %}<span class="c-archive__cat">{{ post.categories | first }}</span>{% endif %}
+        </li>
+        {% endfor %}
+      </ul>
     </div>
-    <ul class="c-archive__list">
-      {% for post in year_group.items %}
-      <li class="c-archive__item">
-        <span class="c-archive__date">{{ post.date | date: '%b %d' }}</span>
-        <a class="c-archive__title" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-        {% if post.categories.size > 0 %}<span class="c-archive__cat">{{ post.categories | first }}</span>{% endif %}
-      </li>
-      {% endfor %}
-    </ul>
+    {% endfor %}
   </div>
-  {% endfor %}
 
+  {% comment %} ===== BY MOOD ===== {% endcomment %}
   {% capture site_tags %}{% for tag in site.tags %}{{ tag | first }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
   {% assign tag_words = site_tags | split:',' | sort %}
 
-  <div class="c-section-heading c-section-heading--spacer">
-    <h3 class="c-section-heading__title">By Mood — Tags</h3>
-    <span class="c-section-heading__meta">{{ tag_words.size }} threads</span>
-  </div>
-
-  <ul class="c-archive-tags">
-    {% for w in tag_words %}
-    <li><a href="#tag-{{ w | cgi_escape }}">{{ w }} <span>{{ site.tags[w].size }}</span></a></li>
-    {% endfor %}
-  </ul>
-
-  {% for w in tag_words %}
-  <div class="c-archive__year c-archive__tag-group" id="tag-{{ w | cgi_escape }}">
-    <div class="c-archive__heading">
-      <span class="c-archive__year-num">{{ w }}</span>
-      <span class="c-archive__year-meta">{{ site.tags[w].size }} {% if site.tags[w].size == 1 %}story{% else %}stories{% endif %}</span>
-    </div>
-    <ul class="c-archive__list">
-      {% for post in site.tags[w] %}{% if post.title %}
-      <li class="c-archive__item">
-        <span class="c-archive__date">{{ post.date | date: '%Y, %b %d' }}</span>
-        <a class="c-archive__title" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-        {% if post.categories.size > 0 %}<span class="c-archive__cat">{{ post.categories | first }}</span>{% endif %}
+  <div class="c-archive-panel" data-archive-panel="mood" hidden>
+    <ul class="c-archive-tags" role="tablist">
+      {% for w in tag_words %}
+      <li>
+        <button type="button" class="c-archive-tag-pill{% if forloop.first %} is-active{% endif %}" data-archive-tag="{{ w | cgi_escape }}" role="tab" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">
+          {{ w }} <span>{{ site.tags[w].size }}</span>
+        </button>
       </li>
-      {% endif %}{% endfor %}
+      {% endfor %}
     </ul>
+
+    {% for w in tag_words %}
+    <div class="c-archive-tag-content"
+         data-archive-tag-content="{{ w | cgi_escape }}"
+         {% unless forloop.first %}hidden{% endunless %}>
+      <div class="c-archive__heading">
+        <span class="c-archive__year-num">{{ w }}</span>
+        <span class="c-archive__year-meta">{{ site.tags[w].size }} {% if site.tags[w].size == 1 %}story{% else %}stories{% endif %}</span>
+      </div>
+      <ul class="c-archive__list">
+        {% for post in site.tags[w] %}{% if post.title %}
+        <li class="c-archive__item">
+          <span class="c-archive__date">{{ post.date | date: '%Y, %b %d' }}</span>
+          <a class="c-archive__title" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+          {% if post.categories.size > 0 %}<span class="c-archive__cat">{{ post.categories | first }}</span>{% endif %}
+        </li>
+        {% endif %}{% endfor %}
+      </ul>
+    </div>
+    {% endfor %}
   </div>
-  {% endfor %}
+
 </section>

--- a/_sass/5-components/_extras.scss
+++ b/_sass/5-components/_extras.scss
@@ -165,45 +165,81 @@
   .c-archive__year-num { font-size: 26px; }
 }
 
-.c-section-heading--spacer {
-  margin-top: 80px;
+/* Sub-tabs at the top of /archive/ */
+.c-archive-tabs {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  margin: 0 0 32px;
+  background: $paper-warm;
+  border: 1px solid $line;
+  border-radius: 999px;
 }
 
-/* Tag pill cloud — sits between the year list and the tag-grouped lists */
+.c-archive-tab {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 8px 18px;
+  font-family: $heading-font-family;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: $muted;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: $global-transition;
+  &:hover { color: $accent; }
+  &.is-active {
+    color: $paper;
+    background: $ink;
+  }
+}
+
+/* Tag pill cloud — sits at the top of the Mood panel */
 .c-archive-tags {
   list-style: none;
-  margin: 0 0 56px;
+  margin: 0 0 32px;
   padding: 0;
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
   li { margin: 0; }
-  a {
-    display: inline-block;
-    padding: 6px 14px;
-    font-family: $heading-font-family;
-    font-size: 13px;
-    color: $ink-soft;
-    background: $paper-warm;
-    border: 1px solid $line;
-    border-radius: 999px;
-    text-decoration: none;
-    transition: $global-transition;
-    span {
-      color: $accent;
-      font-style: italic;
-      font-size: 11px;
-      margin-left: 6px;
-    }
-    &:hover {
-      color: $accent;
-      border-color: $accent-soft;
-      transform: translateY(-1px);
-    }
+}
+
+.c-archive-tag-pill {
+  appearance: none;
+  cursor: pointer;
+  display: inline-block;
+  padding: 6px 14px;
+  font-family: $heading-font-family;
+  font-size: 13px;
+  color: $ink-soft;
+  background: $paper-warm;
+  border: 1px solid $line;
+  border-radius: 999px;
+  text-decoration: none;
+  transition: $global-transition;
+  span {
+    color: $accent;
+    font-style: italic;
+    font-size: 11px;
+    margin-left: 6px;
+  }
+  &:hover {
+    color: $accent;
+    border-color: $accent-soft;
+    transform: translateY(-1px);
+  }
+  &.is-active {
+    color: $paper;
+    background: $ink;
+    border-color: $ink;
+    span { color: $accent-soft; }
   }
 }
 
-.c-archive__tag-group { scroll-margin-top: 80px; }
+.c-archive-tag-content { scroll-margin-top: 80px; }
 
 
 /* ===============

--- a/js/main.js
+++ b/js/main.js
@@ -232,6 +232,50 @@ $(document).ready(function () {
   });
 
   /* =======================
+  // Archive page: Year / Mood sub-tabs + per-tag panels
+  ======================= */
+
+  (function setupArchiveTabs() {
+    var tabs = document.querySelectorAll('.c-archive-tab');
+    var panels = document.querySelectorAll('.c-archive-panel');
+    if (!tabs.length || !panels.length) return;
+
+    tabs.forEach(function (tab) {
+      tab.addEventListener('click', function () {
+        var view = tab.getAttribute('data-archive-view');
+        tabs.forEach(function (t) {
+          var match = t.getAttribute('data-archive-view') === view;
+          t.classList.toggle('is-active', match);
+          t.setAttribute('aria-selected', match ? 'true' : 'false');
+        });
+        panels.forEach(function (p) {
+          var match = p.getAttribute('data-archive-panel') === view;
+          if (match) p.removeAttribute('hidden');
+          else p.setAttribute('hidden', '');
+        });
+      });
+    });
+
+    var tagPills = document.querySelectorAll('.c-archive-tag-pill');
+    var tagContents = document.querySelectorAll('.c-archive-tag-content');
+    tagPills.forEach(function (pill) {
+      pill.addEventListener('click', function () {
+        var tag = pill.getAttribute('data-archive-tag');
+        tagPills.forEach(function (p) {
+          var match = p.getAttribute('data-archive-tag') === tag;
+          p.classList.toggle('is-active', match);
+          p.setAttribute('aria-selected', match ? 'true' : 'false');
+        });
+        tagContents.forEach(function (c) {
+          var match = c.getAttribute('data-archive-tag-content') === tag;
+          if (match) c.removeAttribute('hidden');
+          else c.setAttribute('hidden', '');
+        });
+      });
+    });
+  })();
+
+  /* =======================
   // In-article TOC for long chapter posts
   ======================= */
 


### PR DESCRIPTION
## Summary

Restructure the archive page so finding a specific year or mood doesn't require scrolling through everything.

**Before**: years stacked, then a tag cloud, then every tag's posts piled one after another. Tags were buried ~30 posts deep.

**After**:
- Two pill-style sub-tabs at the top: **By Year** / **By Mood** (Year is the default).
- In the Mood panel, the pill cloud doubles as a *tag selector*. Click a pill → only that tag's stories show below; switch by clicking another pill. No more endless scroll.
- Pills use the same `.is-active` treatment as the topbar so the current selection is unmistakable.

`main.js` wires up two sets of toggles (tabs + pills) using `data-archive-view` and `data-archive-tag` attributes, kept separate from the topbar handlers.

Also a small Liquid fix: the previous draft used Jinja-style `{# ... #}` comments which Liquid passes through as literal text — switched to `{% comment %}…{% endcomment %}`.

## Test plan
- [ ] Open `/archive/` → defaults to "By Year"
- [ ] Click "By Mood" → tag cloud at top, first tag's posts shown below
- [ ] Click another tag pill → posts swap to that tag
- [ ] Click "By Year" → year list returns, mood panel hides

## TOC note
For the inline TOC: this PR doesn't touch it — the previous fix (PR #85) put it at the top of the article body. If the live site still doesn't show it, hard-refresh / open an incognito window and re-visit any chapter post (e.g., `/2026/05/01/sam-bell-moon-au-chapter-4-eight-is-awake/`). It only renders on posts with **3+ subheadings** (like the AU chapter posts).

https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY

---
_Generated by [Claude Code](https://claude.ai/code/session_011ApkJcSc2ieJvUdCWdXcdY)_