### PR TITLE
Fix series status label and reading time for Chinese content

### DIFF
--- a/_posts/2026-05-05-knox-au-simon-says.md
+++ b/_posts/2026-05-05-knox-au-simon-says.md
@@ -7,6 +7,8 @@ tags: [Sam, AU, "Charlie's Angels", 中文]
 categories: ["AU Story"]
 series: "Knox AU"
 series_order: 1
+series_status: complete
+series_type: Oneshot
 summary: "那首歌你第一次听见，是在他宣布他是谁的那个下午。"
 ---
 

--- a/index.html
+++ b/index.html
@@ -155,9 +155,9 @@ layout: home
         {% endif %}
       </div>
       <div class="c-post__body">
-        <div class="c-post__eyebrow">{{ series_cat }} · Series</div>
+        <div class="c-post__eyebrow">{{ series_cat }} · {{ series_first.series_type | default: "Series" }}</div>
         <h3 class="c-post__title">{{ series_name }}</h3>
-        <p class="c-post__summary">{{ series_count }} chapter{% if series_count != 1 %}s{% endif %} · ongoing</p>
+        <p class="c-post__summary">{{ series_count }} chapter{% if series_count != 1 %}s{% endif %} · {{ series_first.series_status | default: "ongoing" }}</p>
       </div>
     </a>
     {% endfor %}
@@ -180,10 +180,10 @@ layout: home
         {% if post.summary %}<p class="c-post__summary">{{ post.summary }}</p>{% endif %}
         <div class="c-post__meta">
           <span>{{ post.date | date: '%Y, %b %d' }}</span>
-          {% capture words %}{{ post.content | number_of_words }}{% endcapture %}
-          {% unless words contains "-" %}
-          <span>{{ words | plus: 250 | divided_by: 250 | append: " min read" }}</span>
-          {% endunless %}
+          {% capture chars %}{{ post.content | strip_html | strip | size }}{% endcapture %}
+          {% assign mins = chars | divided_by: 500 %}
+          {% if mins < 1 %}{% assign mins = 1 %}{% endif %}
+          <span>{{ mins }} min read</span>
         </div>
       </div>
     </a>

--- a/series/a-single-shot-au/index.html
+++ b/series/a-single-shot-au/index.html
@@ -100,10 +100,10 @@ nav_active: "AU Story"
         {% if chapter.summary %}<p class="c-post__summary">{{ chapter.summary }}</p>{% endif %}
         <div class="c-post__meta">
           <span>{{ chapter.date | date: '%Y, %b %d' }}</span>
-          {% capture words %}{{ chapter.content | number_of_words }}{% endcapture %}
-          {% unless words contains "-" %}
-          <span>{{ words | plus: 250 | divided_by: 250 | append: " min read" }}</span>
-          {% endunless %}
+          {% capture chars %}{{ chapter.content | strip_html | strip | size }}{% endcapture %}
+          {% assign mins = chars | divided_by: 500 %}
+          {% if mins < 1 %}{% assign mins = 1 %}{% endif %}
+          <span>{{ mins }} min read</span>
         </div>
       </div>
     </a>

--- a/series/knox-au/index.html
+++ b/series/knox-au/index.html
@@ -73,10 +73,10 @@ nav_active: "AU Story"
         {% if chapter.summary %}<p class="c-post__summary">{{ chapter.summary }}</p>{% endif %}
         <div class="c-post__meta">
           <span>{{ chapter.date | date: '%Y, %b %d' }}</span>
-          {% capture words %}{{ chapter.content | number_of_words }}{% endcapture %}
-          {% unless words contains "-" %}
-          <span>{{ words | plus: 250 | divided_by: 250 | append: " min read" }}</span>
-          {% endunless %}
+          {% capture chars %}{{ chapter.content | strip_html | strip | size }}{% endcapture %}
+          {% assign mins = chars | divided_by: 500 %}
+          {% if mins < 1 %}{% assign mins = 1 %}{% endif %}
+          <span>{{ mins }} min read</span>
         </div>
       </div>
     </a>

--- a/series/sam-bell-moon-au/index.html
+++ b/series/sam-bell-moon-au/index.html
@@ -103,10 +103,10 @@ nav_active: "AU Story"
         {% if chapter.summary %}<p class="c-post__summary">{{ chapter.summary }}</p>{% endif %}
         <div class="c-post__meta">
           <span>{{ chapter.date | date: '%Y, %b %d' }}</span>
-          {% capture words %}{{ chapter.content | number_of_words }}{% endcapture %}
-          {% unless words contains "-" %}
-          <span>{{ words | plus: 250 | divided_by: 250 | append: " min read" }}</span>
-          {% endunless %}
+          {% capture chars %}{{ chapter.content | strip_html | strip | size }}{% endcapture %}
+          {% assign mins = chars | divided_by: 500 %}
+          {% if mins < 1 %}{% assign mins = 1 %}{% endif %}
+          <span>{{ mins }} min read</span>
         </div>
       </div>
     </a>


### PR DESCRIPTION
## Summary

- Knox AU 系列卡片显示 "Oneshot · complete"，不再错标 "Series · ongoing"
- 全站阅读时间从 `number_of_words`（对中文失效）改为字符数估算（`strip_html | size ÷ 500`），Moon AU / A Single Shot AU / Knox AU 及主页卡片统一修复

## Test plan

- [ ] 主页 AU Story 过滤下，Knox AU 卡片显示 "AU Story · Oneshot" 和 "1 chapter · complete"
- [ ] Moon AU / A Single Shot AU 卡片仍显示 "ongoing"（未被影响）
- [ ] Knox AU 章节阅读时间约 6 min read
- [ ] Moon AU / A Single Shot AU 各章节阅读时间合理（不再显示 1 min read）

https://claude.ai/code/session_016CnrozMg26NwgaotPUof4u

---
_Generated by [Claude Code](https://claude.ai/code/session_016CnrozMg26NwgaotPUof4u)_