### PR TITLE
Add cover image to all Zaphod AU chapters

### DIFF
--- a/_posts/2026-05-08-zaphod-au-prequel.md
+++ b/_posts/2026-05-08-zaphod-au-prequel.md
@@ -2,6 +2,7 @@
 layout: post
 title: "前传 · Before the Heart of Gold — Zaphod AU"
 date: 2026-05-08
+image: zaphod-au.jpg
 tags: [Sam, AU, "Hitchhiker's Guide", 中文]
 categories: ["AU Story"]
 series: "Zaphod AU"

--- a/_posts/2026-05-09-zaphod-au-chapter-1-first-day.md
+++ b/_posts/2026-05-09-zaphod-au-chapter-1-first-day.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Chapter 1 · First Day on the Heart of Gold — Zaphod AU"
 date: 2026-05-09
+image: zaphod-au.jpg
 tags: [Sam, AU, "Hitchhiker's Guide", 中文]
 categories: ["AU Story"]
 series: "Zaphod AU"

--- a/_posts/2026-05-09-zaphod-au-chapter-2-first-improbability-party.md
+++ b/_posts/2026-05-09-zaphod-au-chapter-2-first-improbability-party.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Chapter 2 · The First Improbability Party — Zaphod AU"
 date: 2026-05-09
+image: zaphod-au.jpg
 tags: [Sam, AU, "Hitchhiker's Guide", 中文]
 categories: ["AU Story"]
 series: "Zaphod AU"

--- a/_posts/2026-05-09-zaphod-au-chapter-3-velvet-knife.md
+++ b/_posts/2026-05-09-zaphod-au-chapter-3-velvet-knife.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Chapter 3 · The Velvet Knife — Zaphod AU"
 date: 2026-05-09
+image: zaphod-au.jpg
 tags: [Sam, AU, "Hitchhiker's Guide", 中文]
 categories: ["AU Story"]
 series: "Zaphod AU"

--- a/_posts/2026-05-09-zaphod-au-chapter-4-official-fiancee.md
+++ b/_posts/2026-05-09-zaphod-au-chapter-4-official-fiancee.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Chapter 4 · The Official Fiancée — Zaphod AU"
 date: 2026-05-09
+image: zaphod-au.jpg
 tags: [Sam, AU, "Hitchhiker's Guide", 中文]
 categories: ["AU Story"]
 series: "Zaphod AU"

--- a/_posts/2026-05-09-zaphod-au-chapter-5-screw-politics.md
+++ b/_posts/2026-05-09-zaphod-au-chapter-5-screw-politics.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Chapter 5 · Screw Politics — Zaphod AU"
 date: 2026-05-09
+image: zaphod-au.jpg
 tags: [Sam, AU, "Hitchhiker's Guide", 中文]
 categories: ["AU Story"]
 series: "Zaphod AU"


### PR DESCRIPTION
为 Zaphod AU 全部六个章节（前传 + Chapters 1–5）添加封面图 `zaphod-au.jpg`，系列首页的章节卡片将显示封面。

---
_Generated by [Claude Code](https://claude.ai/code/session_016CnrozMg26NwgaotPUof4u)_