### PR TITLE
fix BuzzFeed post date to avoid Jekyll future filter

### DIFF
--- a/_posts/2026-05-10-sam-rockwell-buzzfeed-56-things.md
+++ b/_posts/2026-05-10-sam-rockwell-buzzfeed-56-things.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Sam Rockwell 对 56 件事的看法 · BuzzFeed 2014 采访全注"
-date: 2026-05-10 12:00:00
+date: 2026-05-10 00:00:00
 image: sam-bell-moon-au.jpg
 tags: [Sam, 中文, interview]
 categories: Daily


### PR DESCRIPTION
将文章时间从 `12:00:00` 改为 `00:00:00`。

原因：Jekyll 默认 `future: false`，PR merge 时间是 11:56 UTC，而文章时间设的是 12:00:00，构建时文章还是「未来」时间，被过滤掉未输出。

https://claude.ai/code/session_01HiVe5SS3fwfktXQ2HxpNQi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiVe5SS3fwfktXQ2HxpNQi)_