### PR TITLE
Reorder radar vertices for opposite-dimension symmetry

### DIFF
--- a/sam/many-faces/index.html
+++ b/sam/many-faces/index.html
@@ -26,9 +26,9 @@ const { useEffect } = React;
 const DIMS = [
   { key: "burn",    cn: "燃烧", en: "BURN" },
   { key: "forbear", cn: "隐忍", en: "FORBEAR" },
-  { key: "romance", cn: "浪漫", en: "ROMANCE" },
   { key: "chaos",   cn: "疯狂", en: "CHAOS" },
   { key: "raw",     cn: "璞真", en: "RAW" },
+  { key: "romance", cn: "浪漫", en: "ROMANCE" },
   { key: "grace",   cn: "优雅", en: "GRACE" },
 ];
 

--- a/src/sam/sam_gallery.jsx
+++ b/src/sam/sam_gallery.jsx
@@ -3,9 +3,9 @@ import { useEffect } from "react";
 const DIMS = [
   { key: "burn",    cn: "燃烧", en: "BURN" },
   { key: "forbear", cn: "隐忍", en: "FORBEAR" },
-  { key: "romance", cn: "浪漫", en: "ROMANCE" },
   { key: "chaos",   cn: "疯狂", en: "CHAOS" },
   { key: "raw",     cn: "璞真", en: "RAW" },
+  { key: "romance", cn: "浪漫", en: "ROMANCE" },
   { key: "grace",   cn: "优雅", en: "GRACE" },
 ];
 


### PR DESCRIPTION
调整雷达图六个顶点的顺时针排列顺序，使三对对立维度正对：

- 燃烧（顶）↔ 璞真（底）
- 隐忍（右上）↔ 浪漫（左下）
- 疯狂（右下）↔ 优雅（左上）

同步更新 `src/sam/sam_gallery.jsx` 和 `sam/many-faces/index.html`。

---
_Generated by [Claude Code](https://claude.ai/code/session_016CnrozMg26NwgaotPUof4u)_