### PR TITLE
综合更新：Zaphod AU · Sam Gallery 六维雷达 · UI 改进 · Favicon

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,8 @@
 
   <title>{% if page.title and page.url != '/' %}{{ page.title }} · {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name='description' content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-  <link rel='shotcut icon' href="{{site.baseurl}}/images/{% if site.author-image %}{{site.author-image}}{% endif %}">
+  <link rel="icon" type="image/jpeg" href="{{site.baseurl}}/images/heading-normal.jpg">
+  <link rel="apple-touch-icon" href="{{site.baseurl}}/images/heading-normal.jpg">
   <link rel='canonical' href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel='alternate' type='application/rss+xml' title='{{ site.title }}' href="{{ '/feed.xml' | prepend: site.baseurl | prepend: site.url }}">
   <!-- Set theme before paint to avoid flash -->

--- a/sam/many-faces/index.html
+++ b/sam/many-faces/index.html
@@ -902,6 +902,25 @@ function CharacterCard({ c, idx }) {
         }}>
           ❦
         </div>
+
+        <div style={{ textAlign: "center", marginTop: "20px" }}>
+          <button
+            onClick={function() { window.scrollTo({ top: 0, behavior: "smooth" }); }}
+            style={{
+              background: "transparent",
+              border: "none",
+              cursor: "pointer",
+              fontFamily: "'Special Elite', monospace",
+              fontSize: "0.62rem",
+              color: c.muted,
+              letterSpacing: "0.28em",
+              opacity: 0.65,
+              padding: "4px 0",
+            }}
+          >
+            ↑ CONTENTS
+          </button>
+        </div>
       </div>
     </section>
   );
@@ -1055,21 +1074,23 @@ function SamGallery() {
                     }}>
                       {String(i + 1).padStart(2, "0")}
                     </span>
-                    <span style={{
-                      fontFamily: "'Playfair Display', serif",
-                      fontStyle: "italic",
-                      fontSize: "1rem",
-                      color: "#2a1410",
-                      flex: 1,
-                    }}>
-                      {c.name}
-                    </span>
-                    <span style={{
-                      fontFamily: "'Special Elite', monospace",
-                      fontSize: "0.7rem",
-                      color: "#7a3a26",
-                    }}>
-                      {c.year}
+                    <span style={{ flex: 1, display: "flex", flexDirection: "column", gap: "2px" }}>
+                      <span style={{
+                        fontFamily: "'Playfair Display', serif",
+                        fontStyle: "italic",
+                        fontSize: "1rem",
+                        color: "#2a1410",
+                      }}>
+                        {c.name}
+                      </span>
+                      <span style={{
+                        fontFamily: "'Special Elite', monospace",
+                        fontSize: "0.62rem",
+                        color: "#7a3a26",
+                        letterSpacing: "0.05em",
+                      }}>
+                        {c.film} · {c.year}
+                      </span>
                     </span>
                   </button>
                 );

--- a/src/sam/sam_gallery.jsx
+++ b/src/sam/sam_gallery.jsx
@@ -710,6 +710,25 @@ function CharacterCard({ c, idx }) {
         }}>
           ❦
         </div>
+
+        <div style={{ textAlign: "center", marginTop: "20px" }}>
+          <button
+            onClick={function() { window.scrollTo({ top: 0, behavior: "smooth" }); }}
+            style={{
+              background: "transparent",
+              border: "none",
+              cursor: "pointer",
+              fontFamily: "'Special Elite', monospace",
+              fontSize: "0.62rem",
+              color: c.muted,
+              letterSpacing: "0.28em",
+              opacity: 0.65,
+              padding: "4px 0",
+            }}
+          >
+            ↑ CONTENTS
+          </button>
+        </div>
       </div>
     </section>
   );
@@ -866,21 +885,23 @@ export default function SamGallery() {
                     }}>
                       {String(i + 1).padStart(2, "0")}
                     </span>
-                    <span style={{
-                      fontFamily: "'Playfair Display', serif",
-                      fontStyle: "italic",
-                      fontSize: "1rem",
-                      color: "#2a1410",
-                      flex: 1,
-                    }}>
-                      {c.name}
-                    </span>
-                    <span style={{
-                      fontFamily: "'Special Elite', monospace",
-                      fontSize: "0.7rem",
-                      color: "#7a3a26",
-                    }}>
-                      {c.year}
+                    <span style={{ flex: 1, display: "flex", flexDirection: "column", gap: "2px" }}>
+                      <span style={{
+                        fontFamily: "'Playfair Display', serif",
+                        fontStyle: "italic",
+                        fontSize: "1rem",
+                        color: "#2a1410",
+                      }}>
+                        {c.name}
+                      </span>
+                      <span style={{
+                        fontFamily: "'Special Elite', monospace",
+                        fontSize: "0.62rem",
+                        color: "#7a3a26",
+                        letterSpacing: "0.05em",
+                      }}>
+                        {c.film} · {c.year}
+                      </span>
                     </span>
                   </button>
                 );


### PR DESCRIPTION
本 PR 包含近期所有更新，统一合并。

---

**Zaphod AU 系列**
- 新建系列首页 `/series/zaphod-au/`（开场引言、关于这个系列、关系注脚）
- 前传 + Chapters 1–5 共六章
- 读者角色明确为 Winter
- 所有章节设置封面图 `zaphod-au.jpg`
- Chapter 4 比喻替换

**Sam Gallery**
- 新增角色：Zaphod Beeblebrox、Watson Bryant
- 所有角色 profile 从五维升级为六维（burn / forbear / romance / chaos / raw / grace）
- 雷达图从五边形改为六边形，顶点顺时针排列使对立维度正对
- 目录条目新增电影名 + 年份两行显示
- 每张角色卡片底部新增 ↑ CONTENTS 返回按钮
- 两个文件（JSX 源文件 + 部署 HTML）全部同步

**其他**
- Favicon 从默认字母 G 改为博客头像 `heading-normal.jpg`（同时修了原标签的拼写错误）

---
_Generated by [Claude Code](https://claude.ai/code/session_016CnrozMg26NwgaotPUof4u)_