### PR TITLE
add reusable source-card component

### DIFF
--- a/_includes/main.scss
+++ b/_includes/main.scss
@@ -38,6 +38,7 @@
 @import '5-components/hello';
 @import '5-components/extras';
 @import '5-components/article-page';
+@import '5-components/source-card';
 @import '5-components/tags';
 @import '5-components/header';
 @import '5-components/categories';

--- a/_includes/source-card.html
+++ b/_includes/source-card.html
@@ -1,0 +1,20 @@
+<div class="c-source-card">
+  <a class="c-source-card__link" href="{{ include.url }}" target="_blank" rel="noopener" aria-label="{{ include.title }}"></a>
+  <div class="c-source-card__brand" style="background:{{ include.brand_bg | default: '#1f1d1a' }};color:{{ include.brand_fg | default: '#ffffff' }};">
+    {{ include.brand }}
+  </div>
+  <div class="c-source-card__body">
+    {% if include.category or include.date %}
+    <div class="c-source-card__meta">
+      {% if include.category %}{{ include.category }}{% endif %}
+      {% if include.category and include.date %} · {% endif %}
+      {% if include.date %}{{ include.date }}{% endif %}
+    </div>
+    {% endif %}
+    <p class="c-source-card__title">{{ include.title }}</p>
+    {% if include.quote %}
+    <p class="c-source-card__quote">&ldquo;{{ include.quote }}&rdquo;</p>
+    {% endif %}
+    <span class="c-source-card__cta">{{ include.domain | default: include.url }} →</span>
+  </div>
+</div>

--- a/_posts/2026-05-10-sam-rockwell-buzzfeed-56-things.md
+++ b/_posts/2026-05-10-sam-rockwell-buzzfeed-56-things.md
@@ -11,17 +11,17 @@ summary: "BuzzFeed 问了他 56 件事，每一条都像他本人的一张切片
 # Sam Rockwell 对 56 件随机事物的看法
 ## ——2014 年 BuzzFeed 经典采访逐题中英对照与注释
 
-<a href="https://www.buzzfeed.com/mjs538/sam-rockwells-opinion-on-random-things" target="_blank" rel="noopener" style="display:flex;max-width:640px;margin:24px 0;border:1px solid #e1e4e8;border-radius:12px;overflow:hidden;text-decoration:none;color:inherit;background:#fff;box-shadow:0 2px 8px rgba(0,0,0,0.06);font-family:-apple-system,BlinkMacSystemFont,'PingFang SC','Helvetica Neue',sans-serif;">
-  <div style="flex-shrink:0;width:140px;background:#FFE600;display:flex;align-items:center;justify-content:center;padding:20px 12px;">
-    <span style="color:#ee3322;font-weight:900;font-size:24px;letter-spacing:-1px;line-height:1;text-align:center;">BuzzFeed</span>
-  </div>
-  <div style="padding:16px 20px;flex:1;min-width:0;">
-    <div style="font-size:11px;color:#6a737d;text-transform:uppercase;letter-spacing:0.6px;margin-bottom:8px;">Celebrity · Dec 22, 2014</div>
-    <div style="font-size:16px;font-weight:600;line-height:1.35;margin-bottom:6px;color:#24292e;">Sam Rockwell's Opinion On 56 Completely Random Things</div>
-    <div style="font-size:13px;color:#586069;line-height:1.45;margin-bottom:10px;font-style:italic;">"He would rather poop a softball."</div>
-    <div style="font-size:11px;color:#959da5;">buzzfeed.com →</div>
-  </div>
-</a>
+{% include source-card.html
+  url="https://www.buzzfeed.com/mjs538/sam-rockwells-opinion-on-random-things"
+  brand="BuzzFeed"
+  brand_bg="#FFE600"
+  brand_fg="#ee3322"
+  category="Celebrity"
+  date="Dec 22, 2014"
+  title="Sam Rockwell's Opinion On 56 Completely Random Things"
+  quote="He would rather poop a softball."
+  domain="buzzfeed.com"
+%}
 
 > **来源：** BuzzFeed, 2014 年 12 月 22 日
 > **作者：** Matt Stopera, Whitney Jefferson, Arielle Calderon

--- a/_sass/5-components/_source-card.scss
+++ b/_sass/5-components/_source-card.scss
@@ -1,0 +1,85 @@
+/* ===============
+   SOURCE CARD
+   用于文章内引用来源——采访、文章、报道等
+=============== */
+
+.c-source-card {
+  position: relative;
+  display: block;
+  margin: 36px 0;
+  border: 1px solid var(--c-line);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--c-paper);
+  box-shadow: 0 2px 10px rgba(var(--rgb-shadow), 0.06);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+  max-width: 600px;
+
+  &:hover {
+    box-shadow: 0 4px 18px rgba(var(--rgb-shadow), 0.12);
+    border-color: var(--c-line-strong);
+  }
+}
+
+// 覆盖整张卡片的透明链接层
+.c-source-card__link {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+// 品牌色块
+.c-source-card__brand {
+  padding: 14px 20px;
+  font-family: $heading-font-family;
+  font-weight: 700;
+  font-size: 20px;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+
+// 正文区
+.c-source-card__body {
+  padding: 14px 20px 18px;
+  border-top: 1px solid var(--c-line);
+}
+
+// 分类 · 日期 元数据行
+.c-source-card__meta {
+  font-family: $heading-font-family;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--c-muted);
+  margin: 0 0 8px;
+}
+
+// 文章标题
+.c-source-card__title {
+  font-family: $heading-font-family;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--c-ink);
+  line-height: 1.4;
+  margin: 0 0 6px;
+}
+
+// 引语
+.c-source-card__quote {
+  font-family: $base-font-family;
+  font-style: italic;
+  font-size: 13px;
+  color: var(--c-muted);
+  line-height: 1.55;
+  margin: 0 0 12px;
+}
+
+// 域名 / CTA
+.c-source-card__cta {
+  display: inline-block;
+  font-family: $heading-font-family;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--c-muted-soft);
+}


### PR DESCRIPTION
新增可复用的来源卡片组件，并修复 BuzzFeed 文章的渲染问题。

**变更：**
- `_includes/source-card.html`：Jekyll include，支持 brand / title / quote / date 等参数
- `_sass/5-components/_source-card.scss`：卡片样式，风格与博客一致
- `_includes/main.scss`：引入新组件
- 修复 BuzzFeed 文章中原始 HTML（`<a>` 包裹 `<div>`）导致 Kramdown 渲染出 `</a>` 文本的 bug，改为 include 调用

**以后使用方式：**
```liquid
{% include source-card.html
  url="https://..."
  brand="媒体名"
  brand_bg="#FFE600"
  brand_fg="#ee3322"
  category="分类"
  date="日期"
  title="文章标题"
  quote="引语"
  domain="example.com"
%}
```

https://claude.ai/code/session_01HiVe5SS3fwfktXQ2HxpNQi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiVe5SS3fwfktXQ2HxpNQi)_