### PR TITLE
add c-article-meta component for structured metadata layout

### DIFF
--- a/_posts/2026-05-10-sam-rockwell-buzzfeed-56-things.md
+++ b/_posts/2026-05-10-sam-rockwell-buzzfeed-56-things.md
@@ -23,10 +23,14 @@ summary: "BuzzFeed 问了他 56 件事，每一条都像他本人的一张切片
   domain="buzzfeed.com"
 %}
 
-> **来源：** BuzzFeed, 2014 年 12 月 22 日
-> **作者：** Matt Stopera, Whitney Jefferson, Arielle Calderon
-> **背景：** *Loitering with Intent*（《无所事事》）宣传期采访
-> **整理：** 冬璇 WinterSun · 译注与文化背景说明
+<div class="c-article-meta">
+  <dl>
+    <dt>来源</dt><dd>BuzzFeed, 2014 年 12 月 22 日</dd>
+    <dt>作者</dt><dd>Matt Stopera, Whitney Jefferson, Arielle Calderon</dd>
+    <dt>背景</dt><dd><em>Loitering with Intent</em>（《无所事事》）宣传期采访</dd>
+    <dt>整理</dt><dd>冬璇 WinterSun · 译注与文化背景说明</dd>
+  </dl>
+</div>
 
 ---
 

--- a/_sass/5-components/_source-card.scss
+++ b/_sass/5-components/_source-card.scss
@@ -83,3 +83,43 @@
   letter-spacing: 0.08em;
   color: var(--c-muted-soft);
 }
+
+/* ===============
+   ARTICLE META
+   文章元数据块——来源、作者、背景等信息的两列对齐排版
+   用法：<div class="c-article-meta"><dl>...</dl></div>
+=============== */
+
+.c-article-meta {
+  margin: 24px 0 36px;
+  padding: 16px 20px;
+  border-left: 3px solid var(--c-accent);
+  background: var(--c-bg-soft);
+  border-radius: 0 4px 4px 0;
+
+  dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 5px 16px;
+  }
+
+  dt {
+    font-family: $heading-font-family;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--c-muted);
+    padding-top: 3px;
+    white-space: nowrap;
+  }
+
+  dd {
+    margin: 0;
+    font-family: $base-font-family;
+    font-size: 14px;
+    color: var(--c-ink-soft);
+    line-height: 1.55;
+  }
+}


### PR DESCRIPTION
修复 BuzzFeed 文章元数据块的排版问题，并新增可复用的 `.c-article-meta` 组件。

**问题：** Markdown blockquote 里的连续行会被合并成一段，导致来源/作者/背景/整理全挤在一两行里换行位置不对。

**方案：** 用 `<dl>` + CSS grid 两列布局替代 blockquote，标签（dt）靠左对齐，内容（dd）靠右，每个字段独占一行。

**以后使用方式：**
```html
<div class="c-article-meta">
  <dl>
    <dt>来源</dt><dd>...</dd>
    <dt>作者</dt><dd>...</dd>
  </dl>
</div>
```

https://claude.ai/code/session_01HiVe5SS3fwfktXQ2HxpNQi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiVe5SS3fwfktXQ2HxpNQi)_