### PR TITLE
Unify AU series titles and byline format

### DIFF
--- a/_posts/2026-05-05-knox-au-simon-says.md
+++ b/_posts/2026-05-05-knox-au-simon-says.md
@@ -5,7 +5,7 @@ date: 2026-05-05
 image: knox-au.jpg
 tags: [Sam, AU, "Charlie's Angels", 中文]
 categories: ["AU Story"]
-series: "Knox AU"
+series: "Simon Says"
 series_order: 1
 series_status: complete
 series_type: Oneshot

--- a/_posts/2026-05-06-knox-au-extra-1-the-voice-on-the-phone.md
+++ b/_posts/2026-05-06-knox-au-extra-1-the-voice-on-the-phone.md
@@ -5,7 +5,7 @@ date: 2026-05-06
 image: knox-au.jpg
 tags: [Sam, AU, "Charlie's Angels", 中文]
 categories: ["AU Story"]
-series: "Knox AU"
+series: "Simon Says"
 series_order: 2
 chapter_type: 番外
 summary: "你本来是打算辞职的。"

--- a/_posts/2026-05-08-zaphod-au-prequel.md
+++ b/_posts/2026-05-08-zaphod-au-prequel.md
@@ -5,7 +5,7 @@ date: 2026-05-08
 image: zaphod-au.jpg
 tags: [Sam, AU, "Hitchhiker's Guide", 中文]
 categories: ["AU Story"]
-series: "Zaphod AU"
+series: "Don't Panic, Baby Doll"
 series_order: 1
 series_status: ongoing
 series_type: Series

--- a/_posts/2026-05-09-zaphod-au-chapter-1-first-day.md
+++ b/_posts/2026-05-09-zaphod-au-chapter-1-first-day.md
@@ -5,7 +5,7 @@ date: 2026-05-09
 image: zaphod-au.jpg
 tags: [Sam, AU, "Hitchhiker's Guide", 中文]
 categories: ["AU Story"]
-series: "Zaphod AU"
+series: "Don't Panic, Baby Doll"
 series_order: 2
 series_status: ongoing
 series_type: Series

--- a/_posts/2026-05-09-zaphod-au-chapter-2-first-improbability-party.md
+++ b/_posts/2026-05-09-zaphod-au-chapter-2-first-improbability-party.md
@@ -5,7 +5,7 @@ date: 2026-05-09
 image: zaphod-au.jpg
 tags: [Sam, AU, "Hitchhiker's Guide", 中文]
 categories: ["AU Story"]
-series: "Zaphod AU"
+series: "Don't Panic, Baby Doll"
 series_order: 3
 series_status: ongoing
 series_type: Series

--- a/_posts/2026-05-09-zaphod-au-chapter-3-velvet-knife.md
+++ b/_posts/2026-05-09-zaphod-au-chapter-3-velvet-knife.md
@@ -5,7 +5,7 @@ date: 2026-05-09
 image: zaphod-au.jpg
 tags: [Sam, AU, "Hitchhiker's Guide", 中文]
 categories: ["AU Story"]
-series: "Zaphod AU"
+series: "Don't Panic, Baby Doll"
 series_order: 4
 series_status: ongoing
 series_type: Series

--- a/_posts/2026-05-09-zaphod-au-chapter-4-official-fiancee.md
+++ b/_posts/2026-05-09-zaphod-au-chapter-4-official-fiancee.md
@@ -5,7 +5,7 @@ date: 2026-05-09
 image: zaphod-au.jpg
 tags: [Sam, AU, "Hitchhiker's Guide", 中文]
 categories: ["AU Story"]
-series: "Zaphod AU"
+series: "Don't Panic, Baby Doll"
 series_order: 5
 series_status: ongoing
 series_type: Series

--- a/_posts/2026-05-09-zaphod-au-chapter-5-screw-politics.md
+++ b/_posts/2026-05-09-zaphod-au-chapter-5-screw-politics.md
@@ -5,7 +5,7 @@ date: 2026-05-09
 image: zaphod-au.jpg
 tags: [Sam, AU, "Hitchhiker's Guide", 中文]
 categories: ["AU Story"]
-series: "Zaphod AU"
+series: "Don't Panic, Baby Doll"
 series_order: 6
 series_status: ongoing
 series_type: Series

--- a/series/a-single-shot-au/index.html
+++ b/series/a-single-shot-au/index.html
@@ -13,10 +13,10 @@ nav_active: "AU Story"
   {% endif %}
 
   <div class="c-hero__eyebrow">AU Story · Series</div>
-  <h1 class="c-hero__title">A Single Shot · <em>AU</em></h1>
+  <h1 class="c-hero__title">A Single Shot</h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
-    <span class="c-hero__byline-text">an AU of A Single Shot (2013) · ongoing</span>
+    <span class="c-hero__byline-text">John Moon · A Single Shot (2013) · ongoing</span>
     <span class="c-hero__byline-rule"></span>
   </div>
 

--- a/series/good-enough/index.html
+++ b/series/good-enough/index.html
@@ -16,7 +16,7 @@ nav_active: "AU Story"
   <h1 class="c-hero__title">足够好 ｜ Good Enough</h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
-    <span class="c-hero__byline-text">一个关于「被看见」的贾斯汀·哈默 AU · ongoing</span>
+    <span class="c-hero__byline-text">贾斯汀·哈默 · Iron Man 2 · ongoing</span>
     <span class="c-hero__byline-rule"></span>
   </div>
   <p class="c-hero__lede">

--- a/series/knox-au/index.html
+++ b/series/knox-au/index.html
@@ -13,10 +13,10 @@ nav_active: "AU Story"
   {% endif %}
 
   <div class="c-hero__eyebrow">AU Story · Oneshot</div>
-  <h1 class="c-hero__title">Simon Says · <em>Knox AU</em></h1>
+  <h1 class="c-hero__title">Simon Says</h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
-    <span class="c-hero__byline-text">a Charlie's Angels AU · oneshot</span>
+    <span class="c-hero__byline-text">Eric Knox · Charlie's Angels · oneshot</span>
     <span class="c-hero__byline-rule"></span>
   </div>
 
@@ -49,7 +49,7 @@ nav_active: "AU Story"
   </p>
 </article>
 
-{% assign chapters = site.posts | where: "series", "Knox AU" | sort: "series_order" %}
+{% assign chapters = site.posts | where: "series", "Simon Says" | sort: "series_order" %}
 
 <section class="c-sam-collection">
   <div class="c-section-heading">

--- a/series/sam-bell-moon-au/index.html
+++ b/series/sam-bell-moon-au/index.html
@@ -16,7 +16,7 @@ nav_active: "AU Story"
   <h1 class="c-hero__title">Sam Bell · <em>Moon AU</em></h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
-    <span class="c-hero__byline-text">an AU of Moon (2009) · ongoing</span>
+    <span class="c-hero__byline-text">Sam Bell · Moon (2009) · ongoing</span>
     <span class="c-hero__byline-rule"></span>
   </div>
 

--- a/series/zaphod-au/index.html
+++ b/series/zaphod-au/index.html
@@ -16,7 +16,7 @@ nav_active: "AU Story"
   <h1 class="c-hero__title">Don't Panic, <em>Baby Doll</em></h1>
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
-    <span class="c-hero__byline-text">a Hitchhiker's Guide to the Galaxy AU · ongoing</span>
+    <span class="c-hero__byline-text">Zaphod Beeblebrox · Hitchhiker's Guide · ongoing</span>
     <span class="c-hero__byline-rule"></span>
   </div>
 
@@ -90,7 +90,7 @@ nav_active: "AU Story"
   </p>
 </article>
 
-{% assign chapters = site.posts | where: "series", "Zaphod AU" | sort: "series_order" %}
+{% assign chapters = site.posts | where: "series", "Don't Panic, Baby Doll" | sort: "series_order" %}
 
 <section class="c-sam-collection">
   <div class="c-section-heading">


### PR DESCRIPTION
## 改动内容

### 卡片标题统一（有创意故事名的用故事名）
- "Zaphod AU" → **"Don't Panic, Baby Doll"**（6篇文章 + 索引页）
- "Knox AU" → **"Simon Says"**（2篇文章 + 索引页）

### 系列页面 H1 清理
- Knox：`Simon Says · Knox AU` → `Simon Says`
- A Single Shot：`A Single Shot · AU` → `A Single Shot`

### 副标题格式统一为 `角色 · 来源作品 · 状态`
| 系列 | 新副标题 |
|---|---|
| Don't Panic, Baby Doll | Zaphod Beeblebrox · Hitchhiker's Guide · ongoing |
| Simon Says | Eric Knox · Charlie's Angels · oneshot |
| Good Enough | 贾斯汀·哈默 · Iron Man 2 · ongoing |
| Sam Bell Moon AU | Sam Bell · Moon (2009) · ongoing |
| A Single Shot | John Moon · A Single Shot (2013) · ongoing |

https://claude.ai/code/session_01YEGyPJbHwt1BKt51eVTSJN

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEGyPJbHwt1BKt51eVTSJN)_