### PR TITLE
Sam tab: 动态收集 AU 系列卡片，用 sam_collection flag 区分 Sam 本人角色

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,36 @@ grep -E '^summary:' _posts/<file>.md | sed 's/^summary: *"//; s/"$//' | awk '{pr
 应该是 ~105。要精确按字符数可以用 Python：
 `python3 -c "import sys; print(len(sys.argv[1]))" "<summary 内容>"`）
 
+## Sam tab 的 The Collection（AU 系列卡片）
+
+`/sam/`（`sam/index.html`）里「The Collection」区块的 AU 系列卡片是
+**动态生成**的：模板遍历 `site.pages`，挑出 front matter 里写了
+`sam_collection: true` 的 `series/*/index.html`，按 `collection_order`
+升序排列。所以**新增一个 Sam 的 AU 系列时不用动 `sam/index.html`**，
+只要在该系列的 `index.html` front matter 里加上这几个字段即可：
+
+```yaml
+sam_collection: true            # 出现在 Sam tab 的开关
+collection_order: 6             # 排序，数字越小越靠前
+collection_eyebrow: "AU Story · Series"   # 卡片小标签（oneshot 用 "AU Story · Oneshot"）
+collection_title: "标题 · 角色 AU"         # 卡片标题
+collection_desc: "一两句简介，钩子即可。"   # 卡片描述
+```
+
+**关键规则：`sam_collection` 只给 Sam Rockwell 本人演过的角色。**
+这是一个**显式 opt-in 开关**——不加就不会出现，所以不可能把别人的
+角色误收进来。判断标准是「这个角色是不是 Sam 本人演的」，而不是
+「这篇 AU 在不在 `series/` 目录里」。例如：
+
+- ✅ Sam Bell（Moon）、John Moon（A Single Shot）、Eric Knox
+  (Charlie's Angels)、Zaphod（银河系漫游指南）、Justin Hammer
+  (Iron Man 2) —— 都是 Sam 的角色，已加 flag。
+- ❌ Leonard Shelby（《记忆碎片》）是 **Guy Pearce** 的角色，不是
+  Sam。所以 `series/you-are-my-fact/` **故意不加** `sam_collection`，
+  不进 Sam tab。（该文 front matter 里已留注释说明。）
+
+不确定某个角色是不是 Sam 演的，就先问用户，别擅自加 flag。
+
 ## 其他
 
 - 工作分支：`claude/redesign-blog-homepage-RSiJO`（首页改版相关）。

--- a/sam/index.html
+++ b/sam/index.html
@@ -123,6 +123,24 @@ title: Sam
       <span class="c-sam-card__cta">Open in new tab →</span>
     </a>
 
+    <a class="c-sam-card" href="{{site.baseurl}}/series/you-are-my-fact/" target="_blank" rel="noopener">
+      <div class="c-sam-card__eyebrow">AU Story · Series <span class="c-sam-card__tab">↗</span></div>
+      <h4 class="c-sam-card__title">You Are My Fact · Leonard Shelby AU</h4>
+      <p class="c-sam-card__desc">
+        《记忆碎片》里那个永远记不住你的 Leonard Shelby。你什么都不向他要，只把自己一笔一笔写进他唯一愿意相信的"事实"里。他忘记你多少次，你就比那个数字再多出现一次。会一章一章慢慢长。
+      </p>
+      <span class="c-sam-card__cta">Open in new tab →</span>
+    </a>
+
+    <a class="c-sam-card" href="{{site.baseurl}}/series/good-enough/" target="_blank" rel="noopener">
+      <div class="c-sam-card__eyebrow">AU Story · Series <span class="c-sam-card__tab">↗</span></div>
+      <h4 class="c-sam-card__title">Good Enough · Justin Hammer AU</h4>
+      <p class="c-sam-card__desc">
+        《钢铁侠 2》里被全世界当成笑话的 Justin Hammer。你是无人机项目组里唯一看见他眼镜后面那个真实的人——把他从斯塔克的影子、从一场注定的灾难、也从他自己的孤独里一点点接住。会一章一章慢慢长。
+      </p>
+      <span class="c-sam-card__cta">Open in new tab →</span>
+    </a>
+
     {% assign sam_posts = site.posts | where_exp: "post", "post.tags contains 'Sam'" %}
     {% for post in sam_posts %}{% unless post.series %}
     <a class="c-sam-card" href="{{ post.url | prepend: site.baseurl }}" target="_blank" rel="noopener">

--- a/sam/index.html
+++ b/sam/index.html
@@ -87,59 +87,23 @@ title: Sam
       <span class="c-sam-card__cta">Open in new tab →</span>
     </a>
 
-    <a class="c-sam-card" href="{{site.baseurl}}/series/sam-bell-moon-au/" target="_blank" rel="noopener">
-      <div class="c-sam-card__eyebrow">AU Story · Series <span class="c-sam-card__tab">↗</span></div>
-      <h4 class="c-sam-card__title">Sam Bell · Moon AU</h4>
-      <p class="c-sam-card__desc">
-        与一整屋的 Sam Bell 同居月球基地。原片之外的另一种结局——Sarang 不再是流水线工厂，而成了我们一起的家。会一章一章慢慢长。
-      </p>
+    {%- comment -%}
+      AU 系列卡片：动态从 series/*/index.html 收集。
+      只有在某个系列的 front matter 里显式写了 `sam_collection: true`
+      （即「这是 Sam Rockwell 本人演过的角色」）才会出现在这里。
+      非 Sam 角色的 AU（如 Leonard Shelby / Memento 是 Guy Pearce）
+      不要加这个 flag，自然就不会混进 Sam 的 tab。
+      排序按 `collection_order`（数字越小越靠前）。
+    {%- endcomment -%}
+    {% assign sam_series = site.pages | where_exp: "p", "p.sam_collection" | sort: "collection_order" %}
+    {% for s in sam_series %}
+    <a class="c-sam-card" href="{{ s.url | prepend: site.baseurl }}" target="_blank" rel="noopener">
+      <div class="c-sam-card__eyebrow">{{ s.collection_eyebrow | default: "AU Story · Series" }} <span class="c-sam-card__tab">↗</span></div>
+      <h4 class="c-sam-card__title">{{ s.collection_title | default: s.title }}</h4>
+      {% if s.collection_desc %}<p class="c-sam-card__desc">{{ s.collection_desc }}</p>{% endif %}
       <span class="c-sam-card__cta">Open in new tab →</span>
     </a>
-
-    <a class="c-sam-card" href="{{site.baseurl}}/series/a-single-shot-au/" target="_blank" rel="noopener">
-      <div class="c-sam-card__eyebrow">AU Story · Series <span class="c-sam-card__tab">↗</span></div>
-      <h4 class="c-sam-card__title">A Single Shot AU</h4>
-      <p class="c-sam-card__desc">
-        西弗吉尼亚十月底的阿巴拉契亚山林里，那个他自己挖的坑——电影最后一幕镜头黑下去之后，是你听见了那个呼吸声。关于他等到了天亮的另一种结局。会一章一章慢慢长。
-      </p>
-      <span class="c-sam-card__cta">Open in new tab →</span>
-    </a>
-
-    <a class="c-sam-card" href="{{site.baseurl}}/series/knox-au/" target="_blank" rel="noopener">
-      <div class="c-sam-card__eyebrow">AU Story · Oneshot <span class="c-sam-card__tab">↗</span></div>
-      <h4 class="c-sam-card__title">Simon Says · Knox AU</h4>
-      <p class="c-sam-card__desc">
-        《Charlie's Angels》里的 Eric Knox——蓬头 tech boy 与红镜片掠食者，两个版本都让人欲罢不能。他计划了一切，却没有计划上你。
-      </p>
-      <span class="c-sam-card__cta">Open in new tab →</span>
-    </a>
-
-    <a class="c-sam-card" href="{{site.baseurl}}/series/zaphod-au/" target="_blank" rel="noopener">
-      <div class="c-sam-card__eyebrow">AU Story · Series <span class="c-sam-card__tab">↗</span></div>
-      <h4 class="c-sam-card__title">Don't Panic, Baby Doll · Zaphod AU</h4>
-      <p class="c-sam-card__desc">
-        银河系最混乱的总统，和那个在他背后悄悄校准角度的人。他叫她baby doll，整个银河系都知道这件事，除了他自己。
-      </p>
-      <span class="c-sam-card__cta">Open in new tab →</span>
-    </a>
-
-    <a class="c-sam-card" href="{{site.baseurl}}/series/you-are-my-fact/" target="_blank" rel="noopener">
-      <div class="c-sam-card__eyebrow">AU Story · Series <span class="c-sam-card__tab">↗</span></div>
-      <h4 class="c-sam-card__title">You Are My Fact · Leonard Shelby AU</h4>
-      <p class="c-sam-card__desc">
-        《记忆碎片》里那个永远记不住你的 Leonard Shelby。你什么都不向他要，只把自己一笔一笔写进他唯一愿意相信的"事实"里。他忘记你多少次，你就比那个数字再多出现一次。会一章一章慢慢长。
-      </p>
-      <span class="c-sam-card__cta">Open in new tab →</span>
-    </a>
-
-    <a class="c-sam-card" href="{{site.baseurl}}/series/good-enough/" target="_blank" rel="noopener">
-      <div class="c-sam-card__eyebrow">AU Story · Series <span class="c-sam-card__tab">↗</span></div>
-      <h4 class="c-sam-card__title">Good Enough · Justin Hammer AU</h4>
-      <p class="c-sam-card__desc">
-        《钢铁侠 2》里被全世界当成笑话的 Justin Hammer。你是无人机项目组里唯一看见他眼镜后面那个真实的人——把他从斯塔克的影子、从一场注定的灾难、也从他自己的孤独里一点点接住。会一章一章慢慢长。
-      </p>
-      <span class="c-sam-card__cta">Open in new tab →</span>
-    </a>
+    {% endfor %}
 
     {% assign sam_posts = site.posts | where_exp: "post", "post.tags contains 'Sam'" %}
     {% for post in sam_posts %}{% unless post.series %}

--- a/series/a-single-shot-au/index.html
+++ b/series/a-single-shot-au/index.html
@@ -3,6 +3,12 @@ layout: home
 title: "Into the Mountain · John Moon AU"
 permalink: /series/a-single-shot-au/
 nav_active: "AU Story"
+# Sam Rockwell 本人演过的角色 → 显示在 /sam/ 的 The Collection 里
+sam_collection: true
+collection_order: 2
+collection_eyebrow: "AU Story · Series"
+collection_title: "A Single Shot AU"
+collection_desc: "西弗吉尼亚十月底的阿巴拉契亚山林里，那个他自己挖的坑——电影最后一幕镜头黑下去之后，是你听见了那个呼吸声。关于他等到了天亮的另一种结局。会一章一章慢慢长。"
 ---
 
 <section class="c-hero">

--- a/series/good-enough/index.html
+++ b/series/good-enough/index.html
@@ -3,6 +3,12 @@ layout: home
 title: "Good Enough · Justin Hammer AU"
 permalink: /series/good-enough/
 nav_active: "AU Story"
+# Sam Rockwell 本人演过的角色 → 显示在 /sam/ 的 The Collection 里
+sam_collection: true
+collection_order: 5
+collection_eyebrow: "AU Story · Series"
+collection_title: "Good Enough · Justin Hammer AU"
+collection_desc: "《钢铁侠 2》里被全世界当成笑话的 Justin Hammer。你是无人机项目组里唯一看见他眼镜后面那个真实的人——把他从斯塔克的影子、从一场注定的灾难、也从他自己的孤独里一点点接住。会一章一章慢慢长。"
 ---
 
 <section class="c-hero">

--- a/series/knox-au/index.html
+++ b/series/knox-au/index.html
@@ -3,6 +3,12 @@ layout: home
 title: "Simon Says · Knox AU"
 permalink: /series/knox-au/
 nav_active: "AU Story"
+# Sam Rockwell 本人演过的角色 → 显示在 /sam/ 的 The Collection 里
+sam_collection: true
+collection_order: 3
+collection_eyebrow: "AU Story · Oneshot"
+collection_title: "Simon Says · Knox AU"
+collection_desc: "《Charlie's Angels》里的 Eric Knox——蓬头 tech boy 与红镜片掠食者，两个版本都让人欲罢不能。他计划了一切，却没有计划上你。"
 ---
 
 <section class="c-hero">

--- a/series/sam-bell-moon-au/index.html
+++ b/series/sam-bell-moon-au/index.html
@@ -3,6 +3,12 @@ layout: home
 title: "Far Side · Sam Bell AU"
 permalink: /series/sam-bell-moon-au/
 nav_active: "AU Story"
+# Sam Rockwell 本人演过的角色 → 显示在 /sam/ 的 The Collection 里
+sam_collection: true
+collection_order: 1
+collection_eyebrow: "AU Story · Series"
+collection_title: "Sam Bell · Moon AU"
+collection_desc: "与一整屋的 Sam Bell 同居月球基地。原片之外的另一种结局——Sarang 不再是流水线工厂，而成了我们一起的家。会一章一章慢慢长。"
 ---
 
 <section class="c-hero">

--- a/series/you-are-my-fact/index.html
+++ b/series/you-are-my-fact/index.html
@@ -3,6 +3,8 @@ layout: home
 title: "You Are My Fact · Leonard Shelby AU"
 permalink: /series/you-are-my-fact/
 nav_active: "AU Story"
+# 注意：Leonard Shelby（《记忆碎片》）是 Guy Pearce 的角色，不是 Sam Rockwell。
+# 因此【故意】不加 sam_collection，不要把它收进 /sam/ 的 The Collection。
 ---
 
 <section class="c-hero">

--- a/series/zaphod-au/index.html
+++ b/series/zaphod-au/index.html
@@ -3,6 +3,12 @@ layout: home
 title: "Don't Panic, Baby Doll · Zaphod AU"
 permalink: /series/zaphod-au/
 nav_active: "AU Story"
+# Sam Rockwell 本人演过的角色 → 显示在 /sam/ 的 The Collection 里
+sam_collection: true
+collection_order: 4
+collection_eyebrow: "AU Story · Series"
+collection_title: "Don't Panic, Baby Doll · Zaphod AU"
+collection_desc: "银河系最混乱的总统，和那个在他背后悄悄校准角度的人。他叫她baby doll，整个银河系都知道这件事，除了他自己。"
 ---
 
 <section class="c-hero">


### PR DESCRIPTION
## 背景

`/sam/` 的「The Collection」原本把 AU 系列卡片**硬编码**在 `sam/index.html` 里，导致两个问题：

1. 新增系列要手动补卡片，容易漏（之前 You Are My Fact / Good Enough 就没同步）。
2. 没有机制保证只收录 Sam Rockwell 本人的角色 —— 比如 **Leonard Shelby（《记忆碎片》）其实是 Guy Pearce 的角色，不是 Sam**，却差点被收进去。

## 改动

- **动态化**：`sam/index.html` 的卡片改为遍历 `site.pages`，挑出 front matter 标了 `sam_collection: true` 的 `series/*/index.html`，按 `collection_order` 排序渲染。以后加系列不用再动这个文件。
- **显式 opt-in 区分**：`sam_collection` 是一个手动开关，只给 Sam 本人演过的角色。不加就不会出现，杜绝误收别人的角色。
  - ✅ 已加：Sam Bell（Moon）、John Moon（A Single Shot）、Eric Knox（Charlie's Angels）、Zaphod（银河系漫游指南）、Justin Hammer（Iron Man 2）。
  - ❌ 故意不加：`series/you-are-my-fact/`（Leonard Shelby = Guy Pearce，非 Sam），并在其 front matter 留注释说明。
- **文档**：CLAUDE.md 记录该机制、字段格式与「只收 Sam 本人角色」的判断规则。

## 注意

- 各系列卡片标题 / 描述现在来自系列 `index.html` 的 `collection_*` 字段。
- 站点从 `main` 部署，合并后线上 Sam tab 才会更新。

https://claude.ai/code/session_01B7MaGADugXGNAPQR1GFx8G

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7MaGADugXGNAPQR1GFx8G)_