### PR TITLE
Fix: add missing cover image to You Are My Fact Ch13–15

### DIFF
--- a/_posts/2026-05-31-you-are-my-fact-chapter-13-the-day-you-were-gone.md
+++ b/_posts/2026-05-31-you-are-my-fact-chapter-13-the-day-you-were-gone.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Chapter 13 · 你不在的那一天 — You Are My Fact"
 date: 2026-05-31
+image: leonard-shelby-au.jpg
 tags: [Guy Pearce, Memento, Leonard Shelby, AU, 中文]
 categories: ["AU Story"]
 series: "You Are My Fact"

--- a/_posts/2026-05-31-you-are-my-fact-chapter-14-the-past-can-be-held-gently.md
+++ b/_posts/2026-05-31-you-are-my-fact-chapter-14-the-past-can-be-held-gently.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Chapter 14 · 过去可以被善待 — You Are My Fact"
 date: 2026-05-31
+image: leonard-shelby-au.jpg
 tags: [Guy Pearce, Memento, Leonard Shelby, AU, 中文]
 categories: ["AU Story"]
 series: "You Are My Fact"

--- a/_posts/2026-05-31-you-are-my-fact-chapter-15-its-time-you-gave-me-a-gift.md
+++ b/_posts/2026-05-31-you-are-my-fact-chapter-15-its-time-you-gave-me-a-gift.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Chapter 15 · 你该给我礼物了 — You Are My Fact"
 date: 2026-05-31
+image: leonard-shelby-au.jpg
 tags: [Guy Pearce, Memento, Leonard Shelby, AU, 中文]
 categories: ["AU Story"]
 series: "You Are My Fact"


### PR DESCRIPTION
Ch13–15 were deployed without `image: leonard-shelby-au.jpg`. This adds the missing field so all 15 chapters carry the same cover image.

https://claude.ai/code/session_01YEGyPJbHwt1BKt51eVTSJN

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEGyPJbHwt1BKt51eVTSJN)_