### PR TITLE
Sam Bell · Moon AU：全系列封面换成 sam-bell-au.jpg

### DIFF
--- a/_posts/2026-05-01-sam-bell-moon-au-chapter-1-departure.md
+++ b/_posts/2026-05-01-sam-bell-moon-au-chapter-1-departure.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Chapter 1 · Departure — Sam Bell · Moon AU"
 date: 2026-05-01
-image: sam-bell-moon-au.jpg
+image: sam-bell-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]
 series: "Sam Bell · Moon AU"

--- a/_posts/2026-05-01-sam-bell-moon-au-chapter-2-awakening.md
+++ b/_posts/2026-05-01-sam-bell-moon-au-chapter-2-awakening.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Chapter 2 · Awakening — Sam Bell · Moon AU"
 date: 2026-05-01 12:00:00
-image: sam-bell-moon-au.jpg
+image: sam-bell-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]
 series: "Sam Bell · Moon AU"

--- a/_posts/2026-05-01-sam-bell-moon-au-chapter-3-bringing-him-home.md
+++ b/_posts/2026-05-01-sam-bell-moon-au-chapter-3-bringing-him-home.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Chapter 3 · Bringing Him Home — Sam Bell · Moon AU"
 date: 2026-05-01 14:00:00
-image: sam-bell-moon-au.jpg
+image: sam-bell-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]
 series: "Sam Bell · Moon AU"

--- a/_posts/2026-05-01-sam-bell-moon-au-chapter-4-eight-is-awake.md
+++ b/_posts/2026-05-01-sam-bell-moon-au-chapter-4-eight-is-awake.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Chapter 4 · Eight is awake — Sam Bell · Moon AU"
 date: 2026-05-01 16:00:00
-image: sam-bell-moon-au.jpg
+image: sam-bell-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]
 series: "Sam Bell · Moon AU"

--- a/_posts/2026-05-01-sam-bell-moon-au-chapter-5-one-bed.md
+++ b/_posts/2026-05-01-sam-bell-moon-au-chapter-5-one-bed.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Chapter 5 · One Bed — Sam Bell · Moon AU"
 date: 2026-05-01 18:00:00
-image: sam-bell-moon-au.jpg
+image: sam-bell-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]
 series: "Sam Bell · Moon AU"

--- a/_posts/2026-05-01-sam-bell-moon-au-chapter-6-want.md
+++ b/_posts/2026-05-01-sam-bell-moon-au-chapter-6-want.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Chapter 6 · Want — Sam Bell · Moon AU"
 date: 2026-05-01 20:00:00
-image: sam-bell-moon-au.jpg
+image: sam-bell-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]
 series: "Sam Bell · Moon AU"

--- a/_posts/2026-05-01-sam-bell-moon-au-chapter-7-going-dark.md
+++ b/_posts/2026-05-01-sam-bell-moon-au-chapter-7-going-dark.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Chapter 7 · Going Dark — Sam Bell · Moon AU"
 date: 2026-05-01 21:00:00
-image: sam-bell-moon-au.jpg
+image: sam-bell-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]
 series: "Sam Bell · Moon AU"

--- a/_posts/2026-05-01-sam-bell-moon-au-chapter-8-nine-and-ten.md
+++ b/_posts/2026-05-01-sam-bell-moon-au-chapter-8-nine-and-ten.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Chapter 8 · Nine and Ten — Sam Bell · Moon AU"
 date: 2026-05-01 23:00:00
-image: sam-bell-moon-au.jpg
+image: sam-bell-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]
 series: "Sam Bell · Moon AU"

--- a/_posts/2026-05-02-sam-bell-moon-au-chapter-9-build-a-home.md
+++ b/_posts/2026-05-02-sam-bell-moon-au-chapter-9-build-a-home.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Chapter 9 · Build a Home — Sam Bell · Moon AU"
 date: 2026-05-02 00:00:00
-image: sam-bell-moon-au.jpg
+image: sam-bell-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]
 series: "Sam Bell · Moon AU"

--- a/_posts/2026-05-03-sam-bell-moon-au-chapter-10-the-main-suite.md
+++ b/_posts/2026-05-03-sam-bell-moon-au-chapter-10-the-main-suite.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Chapter 10 · The Main Suite — Sam Bell · Moon AU"
 date: 2026-05-03 02:00:00
-image: sam-bell-moon-au.jpg
+image: sam-bell-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]
 series: "Sam Bell · Moon AU"

--- a/_posts/2026-05-03-sam-bell-moon-au-chapter-11-the-surface.md
+++ b/_posts/2026-05-03-sam-bell-moon-au-chapter-11-the-surface.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Chapter 11 · The Surface — Sam Bell · Moon AU"
 date: 2026-05-03 03:00:00
-image: sam-bell-moon-au.jpg
+image: sam-bell-au.jpg
 tags: [Sam, AU, Moon, 中文]
 categories: ["AU Story"]
 series: "Sam Bell · Moon AU"


### PR DESCRIPTION
把 Sam Bell · Moon AU 系列全部 11 章的封面图从 `sam-bell-moon-au.jpg` 换成新上传的 `sam-bell-au.jpg`（900×544 JPEG，已在 main 上）。

- 改动仅限 11 个章节 front matter 的 `image:` 字段。
- 系列页与各章封面（模板渲染成 background-image）会自动用新图。
- 旧图 `sam-bell-moon-au.jpg` 未删除，仍保留在 images/ 里。

合并到 main 后线上生效。

https://claude.ai/code/session_01B7MaGADugXGNAPQR1GFx8G

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7MaGADugXGNAPQR1GFx8G)_