### PR TITLE
Tuning the Devil (William Wharton AU)：加封面 william-wharton-au.jpeg

### DIFF
--- a/_posts/2026-06-06-tuning-the-devil-setting-overview.md
+++ b/_posts/2026-06-06-tuning-the-devil-setting-overview.md
@@ -3,6 +3,7 @@ layout: post
 title: "为他调音｜设定总览"
 categories: ["AU Story"]
 date: 2026-06-06
+image: william-wharton-au.jpeg
 series: "Tuning the Devil"
 series_title: 'Tuning the Devil · William "Wild Bill" Wharton AU'
 series_order: 0


### PR DESCRIPTION
给 William "Wild Bill" Wharton 的 AU（系列 **Tuning the Devil**）加上封面图 `william-wharton-au.jpeg`（已在 main，900-ish JPEG）。

说明：该系列目前只有一篇「设定总览」（`is_overview: true`），还没有正式章节，之前没有任何封面图。本次把封面加到这唯一的一篇上（`image:` 放在 `date:` 行后）。以后写正式章节时按惯例每章用同一文件名 `william-wharton-au.jpeg` 即可，系列目录卡片会自动带图。

本地 `jekyll build` 通过，设定总览页面已正确渲染该封面。合并到 main 后线上生效。

https://claude.ai/code/session_01B7MaGADugXGNAPQR1GFx8G

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7MaGADugXGNAPQR1GFx8G)_