### PR TITLE
宝丽来文章卡片 + AU 胶片色卡

### DIFF
--- a/_data/au_palettes.yml
+++ b/_data/au_palettes.yml
@@ -4,7 +4,9 @@
 #      以及各章节 front matter 的 series 字段【完全一致】，否则查不到。
 # accent     : 强调色（深色主题 + 色卡用）
 # accent_ink : 浅色主题下用于文字/链接的更深一档（保证对比度）
-# bg         : 背景深色（色卡用）
+# bg         : 背景深色（整页底色 / 色卡用）
+# text       : 该系列专属主题下的正文字色（落在 bg 上要清晰）
+# muted      : 该系列专属主题下的次级字色（日期 / 副标题等）
 # *_cn / *_en: 中英色名（与画册一致）
 # 注：The One Who Remembers 不在此表 —— 故意跳过，页面保持默认主题。
 # ───────────────────────────────────────────────────────────────
@@ -13,6 +15,8 @@
   accent: "#5f96c2"
   accent_ink: "#3f6a92"
   bg: "#1e1a16"
+  text: "#e8e0d4"
+  muted: "#9a8f7e"
   accent_cn: "冰蓝眼眸"
   accent_en: "Ice-Blue Eyes"
   bg_cn: "旧宝丽来"
@@ -22,6 +26,8 @@
   accent: "#b0803e"
   accent_ink: "#8a5f28"
   bg: "#1b1510"
+  text: "#ece1cf"
+  muted: "#9d8f78"
   accent_cn: "锯末粗木"
   accent_en: "Sawdust Timber"
   bg_cn: "炉膛夜黑"
@@ -31,6 +37,8 @@
   accent: "#4a87ee"
   accent_ink: "#2f63c0"
   bg: "#13151c"
+  text: "#dbe2ee"
+  muted: "#8b94a6"
   accent_cn: "电光钴蓝"
   accent_en: "Spotlight Sapphire"
   bg_cn: "落幕玄黑"
@@ -40,6 +48,8 @@
   accent: "#d4a82a"
   accent_ink: "#927012"
   bg: "#0b0a12"
+  text: "#ece2cf"
+  muted: "#9b9078"
   accent_cn: "总统鬃金"
   accent_en: "President's Mane"
   bg_cn: "黑甲漆夜"
@@ -49,6 +59,8 @@
   accent: "#d94040"
   accent_ink: "#b13030"
   bg: "#1b1310"
+  text: "#ece0d6"
+  muted: "#a08d80"
   accent_cn: "红镜红"
   accent_en: "Crimson Lens"
   bg_cn: "可乐棕"
@@ -58,6 +70,8 @@
   accent: "#7eb0d5"
   accent_ink: "#3f7397"
   bg: "#162038"
+  text: "#dfe7f2"
+  muted: "#8ea0b8"
   accent_cn: "基地微光"
   accent_en: "Sarang Glow"
   bg_cn: "月球蔚蓝"
@@ -67,6 +81,8 @@
   accent: "#8fa0b0"
   accent_ink: "#54616e"
   bg: "#14181f"
+  text: "#e0e4ea"
+  muted: "#8e96a2"
   accent_cn: "孤枪冷雾蓝"
   accent_en: "Lone Mist"
   bg_cn: "西弗州山夜"

--- a/_includes/au-palette-strip.html
+++ b/_includes/au-palette-strip.html
@@ -1,0 +1,23 @@
+{%- comment -%}
+  AU 系列胶片色卡：插在系列首页 hero 标题正下方。
+  调用：{% include au-palette-strip.html %}（自动按 page.series_name 查表，
+  不在表里的系列不渲染）。样式 .au-strip 在 au-palette-style.html 里定义。
+{%- endcomment -%}
+{%- assign p = site.data.au_palettes[page.series_name] -%}
+{%- if p -%}
+<div class="au-strip" aria-label="系列配色 · Palette">
+  <span class="au-strip__perf"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></span>
+  <span class="au-strip__frames">
+    <span class="au-strip__frame">
+      <span class="au-strip__dot" style="background: {{ p.accent }}"></span>
+      <span class="au-strip__name"><span class="au-strip__cn">{{ p.accent_cn }}</span><span class="au-strip__en">{{ p.accent_en }}</span></span>
+    </span>
+    <span class="au-strip__div"></span>
+    <span class="au-strip__frame">
+      <span class="au-strip__dot" style="background: {{ p.bg }}"></span>
+      <span class="au-strip__name"><span class="au-strip__cn">{{ p.bg_cn }}</span><span class="au-strip__en">{{ p.bg_en }}</span></span>
+    </span>
+  </span>
+  <span class="au-strip__perf"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></span>
+</div>
+{%- endif -%}

--- a/_includes/au-palette-style.html
+++ b/_includes/au-palette-style.html
@@ -1,53 +1,83 @@
 {%- comment -%}
   AU 系列专属配色样式。调用：{% include au-palette-style.html pal=pal %}
-  把主题强调色变量换成该系列颜色（浅色用 accent_ink、深色用 accent），沿用站点
-  自身明暗机制；并定义画册同款小色卡 .au-card 与章节小标签 .au-tag。
-  仅在 AU 页面（pal 存在时）由布局加载，字体全部用博客已加载的，不新增依赖。
+  整页主题变量整体替换成该系列调色板（以 bg 为底、text 为字、accent 发光），
+  明暗两种模式都强制套用——给这一页一个「专属深色主题」，沉浸感与画册内页一致。
+  并定义胶片色卡 .au-strip（系列首页标题下）与章节小标签 .au-tag。
+  仅 AU 页面（pal 存在时）由布局加载，不影响其它页面与非 AU 系列。
 {%- endcomment -%}
 {%- assign p = include.pal -%}
 <style>
-  :root{
-    --c-accent:      {{ p.accent_ink | default: p.accent }};
-    --c-accent-soft: {{ p.accent_ink | default: p.accent }};
-    --c-accent-dark: {{ p.accent_ink | default: p.accent }};
-  }
+  :root,
   :root[data-theme="dark"]{
+    --c-bg:          {{ p.bg }};
+    --c-bg-soft:     {{ p.bg }};
+    --c-paper:       {{ p.bg }};
+    --c-ink:         {{ p.text }};
+    --c-ink-soft:    {{ p.text }};
+    --c-muted:       {{ p.muted }};
+    --c-muted-soft:  {{ p.muted }};
+    --c-line:        rgba(255,255,255,.10);
+    --c-line-strong: rgba(255,255,255,.20);
     --c-accent:      {{ p.accent }};
     --c-accent-soft: {{ p.accent }};
     --c-accent-dark: {{ p.accent }};
+    --rgb-shadow:    0, 0, 0;
   }
   @media (prefers-color-scheme: dark){
     :root:not([data-theme="light"]){
+      --c-bg:          {{ p.bg }};
+      --c-bg-soft:     {{ p.bg }};
+      --c-paper:       {{ p.bg }};
+      --c-ink:         {{ p.text }};
+      --c-ink-soft:    {{ p.text }};
+      --c-muted:       {{ p.muted }};
+      --c-muted-soft:  {{ p.muted }};
+      --c-line:        rgba(255,255,255,.10);
+      --c-line-strong: rgba(255,255,255,.20);
       --c-accent:      {{ p.accent }};
       --c-accent-soft: {{ p.accent }};
       --c-accent-dark: {{ p.accent }};
+      --rgb-shadow:    0, 0, 0;
     }
   }
-  /* 让大标题也染上这系列的颜色 */
+
+  /* 整页柔和强调色背光（画册同款，随页面固定不滚动） */
+  body{
+    background:
+      radial-gradient(ellipse 90% 55% at 50% 20%, {{ p.accent }}1f 0%, transparent 58%),
+      {{ p.bg }};
+    background-attachment: fixed;
+  }
+  /* 大标题染上强调色 */
   .c-hero__title{ color: var(--c-accent); }
 
-  /* —— 画册同款小色卡（系列首页） —— */
-  .au-card{
-    max-width: 360px; margin: 30px auto 4px; padding: 16px 18px;
-    background: #15130f; border-radius: 12px;
-    box-shadow: 0 10px 30px -10px rgba(0,0,0,.5);
-    display: flex; flex-direction: column; gap: 13px;
+  /* —— 胶片色卡（系列首页标题下方）—— */
+  .au-strip{
+    display: inline-flex; flex-direction: column; gap: 7px;
+    padding: 8px 10px; margin: 6px 0 6px;
+    border-radius: 8px;
+    background: rgba(255,255,255,.05);
+    box-shadow: 0 10px 24px rgba(0,0,0,.5), inset 0 0 0 1px rgba(255,255,255,.10);
   }
-  .au-card__eyebrow{
-    font-family: 'EB Garamond', serif; font-style: italic; font-size: 11px;
-    letter-spacing: .24em; text-transform: uppercase; color: #8f867a;
-  }
-  .au-card__row{ display: flex; align-items: center; gap: 12px; }
-  .au-card__chip{
-    width: 34px; height: 34px; border-radius: 7px; flex: 0 0 auto;
-    box-shadow: inset 0 0 0 1px rgba(255,255,255,.07);
-  }
-  .au-card__cn{ font-family: 'Noto Serif SC', serif; font-size: 15px; color: #ece4d6; line-height: 1.25; }
-  .au-card__en{ font-family: 'EB Garamond', serif; font-style: italic; font-size: 13px; line-height: 1.2; }
+  .au-strip__perf{ display: flex; justify-content: space-between; align-items: center; }
+  .au-strip__perf i{ width: 5px; height: 3px; border-radius: 1px; background: rgba(255,255,255,.40); flex: 0 0 auto; }
+  .au-strip__frames{ display: inline-flex; align-items: stretch; }
+  .au-strip__frame{ display: flex; align-items: center; gap: 10px; padding: 4px 16px; }
+  .au-strip__div{ width: 1px; align-self: stretch; background: rgba(255,255,255,.14); margin: 6px 0; }
+  .au-strip__dot{ width: 24px; height: 24px; border-radius: 50%; flex: 0 0 auto; box-shadow: inset 0 0 0 1px rgba(255,255,255,.16); }
+  .au-strip__name{ display: flex; flex-direction: column; text-align: left; line-height: 1.18; }
+  .au-strip__cn{ font-family: 'Noto Serif SC', serif; font-size: 15px; color: var(--c-ink); }
+  .au-strip__en{ font-family: 'EB Garamond', serif; font-style: italic; font-size: 12.5px; color: var(--c-muted); }
 
-  /* —— 章节页小标签 —— */
-  .au-tag{ display: inline-flex; align-items: center; gap: 9px; margin: 2px 0 16px; }
-  .au-tag__chips{ display: inline-flex; gap: 4px; }
-  .au-tag__chip{ width: 14px; height: 14px; border-radius: 4px; box-shadow: inset 0 0 0 1px rgba(127,127,127,.3); }
-  .au-tag__names{ font-family: 'EB Garamond', serif; font-style: italic; font-size: 12px; letter-spacing: .08em; color: var(--c-muted); }
+  /* —— 章节页小标签（同款胶片质感）—— */
+  .au-tag{
+    display: inline-flex; align-items: center; gap: 10px;
+    margin: 2px 0 18px; padding: 6px 12px;
+    border-radius: 7px;
+    background: rgba(255,255,255,.05);
+    box-shadow: 0 6px 16px rgba(0,0,0,.4), inset 0 0 0 1px rgba(255,255,255,.09);
+  }
+  .au-tag__chips{ display: inline-flex; gap: 5px; }
+  .au-tag__chip{ width: 15px; height: 15px; border-radius: 50%; box-shadow: inset 0 0 0 1px rgba(255,255,255,.18); }
+  .au-tag__names{ font-family: 'EB Garamond', serif; font-style: italic; font-size: 12px; letter-spacing: .06em; color: var(--c-muted); }
 </style>

--- a/_includes/main.scss
+++ b/_includes/main.scss
@@ -34,6 +34,7 @@
 @import '5-components/content';
 @import '5-components/hero';
 @import '5-components/index-post';
+@import '5-components/polaroid';
 @import '5-components/sam';
 @import '5-components/hello';
 @import '5-components/extras';

--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -14,25 +14,6 @@ layout: home
 {% if page.series_name %}
 {% assign all_series_posts = site.posts | where: "series", page.series_name | sort: "series_order" %}
 {% assign chapters = all_series_posts | where_exp: "item", "item.is_overview != true" %}
-{% if pal %}
-<aside class="au-card" aria-label="系列配色 · Palette">
-  <div class="au-card__eyebrow">— Palette —</div>
-  <div class="au-card__row">
-    <span class="au-card__chip" style="background: {{ pal.accent }}"></span>
-    <div>
-      <div class="au-card__cn">{{ pal.accent_cn }}</div>
-      <div class="au-card__en" style="color: {{ pal.accent }}">{{ pal.accent_en }}</div>
-    </div>
-  </div>
-  <div class="au-card__row">
-    <span class="au-card__chip" style="background: {{ pal.bg }}"></span>
-    <div>
-      <div class="au-card__cn">{{ pal.bg_cn }}</div>
-      <div class="au-card__en" style="color: #b6ac9d">{{ pal.bg_en }}</div>
-    </div>
-  </div>
-</aside>
-{% endif %}
 <section class="c-sam-collection" id="chapters">
   <div class="c-section-heading">
     <h3 class="c-section-heading__title">Chapters</h3>

--- a/_sass/5-components/_polaroid.scss
+++ b/_sass/5-components/_polaroid.scss
@@ -1,0 +1,61 @@
+/* ===============
+   POLAROID CARDS
+   把网格文章卡片 .c-post 覆盖成宝丽来照片，全站通用。
+   在 index-post 之后导入，故这些声明生效。
+   相纸与字色固定（明暗两主题一致）；阴影随 --rgb-shadow 自适应。
+=============== */
+
+.c-post {
+  background: #fbf7ef;                 /* 暖白相纸，两主题固定 */
+  border-radius: 3px;
+  padding: 9px 9px 0;
+  box-shadow:
+    0 14px 30px -10px rgba(var(--rgb-shadow), 0.34),
+    0 2px 7px rgba(var(--rgb-shadow), 0.18);
+  transition: transform 0.32s ease, box-shadow 0.32s ease;
+}
+
+/* 照片贴顶，下方留出可“书写”的相纸边 */
+.c-post__image-wrap {
+  aspect-ratio: 4 / 3;
+  border-radius: 1px;
+  margin-bottom: 0;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.10);
+}
+
+.c-post__placeholder {
+  background: linear-gradient(135deg, #efe7d6, #d8cdb8);
+  color: #9a8f7a;
+}
+
+.c-post__body { padding: 13px 7px 17px; }
+
+.c-post__eyebrow { color: #a78f63; }   /* 暖调相纸标签，奶白上清晰 */
+.c-post__title   { color: #26221d; }
+.c-post__summary { color: #5c544a; }
+.c-post__meta    { color: #9a9082; }
+.c-post__meta span + span::before { color: #c8bca6; }
+
+/* 随手摆放的轻微歪斜（很克制） */
+.c-post-grid > .c-post:nth-child(4n+1) { transform: rotate(-0.8deg); }
+.c-post-grid > .c-post:nth-child(4n+2) { transform: rotate(0.5deg); }
+.c-post-grid > .c-post:nth-child(4n+3) { transform: rotate(-0.3deg); }
+.c-post-grid > .c-post:nth-child(4n+4) { transform: rotate(0.7deg); }
+
+/* 悬停：摆正并整体抬起（照片本身不再单独位移） */
+.c-post-grid > .c-post:hover {
+  transform: translateY(-5px) rotate(0deg);
+  box-shadow:
+    0 26px 52px -12px rgba(var(--rgb-shadow), 0.46),
+    0 3px 10px rgba(var(--rgb-shadow), 0.22);
+}
+.c-post:hover .c-post__image-wrap {
+  transform: none;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.10);
+}
+.c-post:hover .c-post__image { transform: none; }
+.c-post:hover .c-post__title { color: #3a2c1f; }
+
+/* 相关推荐（4 列）相纸略收紧 */
+.c-post-grid--quad > .c-post { padding: 7px 7px 0; }
+.c-post-grid--quad .c-post__body { padding: 10px 5px 13px; }

--- a/series/a-single-shot-au/index.html
+++ b/series/a-single-shot-au/index.html
@@ -21,6 +21,7 @@ collection_desc: "西弗吉尼亚十月底的阿巴拉契亚山林里，那个�
 
   <div class="c-hero__eyebrow">AU Story · Series</div>
   <h1 class="c-hero__title">Into the Mountain</h1>
+  {% include au-palette-strip.html %}
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
     <span class="c-hero__byline-text">John Moon · A Single Shot (2013) · ongoing</span>

--- a/series/good-enough/index.html
+++ b/series/good-enough/index.html
@@ -21,6 +21,7 @@ collection_desc: "《钢铁侠 2》里被全世界当成笑话的 Justin Hammer�
 
   <div class="c-hero__eyebrow">AU Story · Series</div>
   <h1 class="c-hero__title">Good Enough</h1>
+  {% include au-palette-strip.html %}
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
     <span class="c-hero__byline-text">Justin Hammer · Iron Man 2 · ongoing</span>

--- a/series/knox-au/index.html
+++ b/series/knox-au/index.html
@@ -21,6 +21,7 @@ collection_desc: "《Charlie's Angels》里的 Eric Knox——蓬头 tech boy �
 
   <div class="c-hero__eyebrow">AU Story · Oneshot</div>
   <h1 class="c-hero__title">Simon Says</h1>
+  {% include au-palette-strip.html %}
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
     <span class="c-hero__byline-text">Eric Knox · Charlie's Angels · oneshot</span>

--- a/series/sam-bell-moon-au/index.html
+++ b/series/sam-bell-moon-au/index.html
@@ -21,6 +21,7 @@ collection_desc: "与一整屋的 Sam Bell 同居月球基地。原片之外的�
 
   <div class="c-hero__eyebrow">AU Story · Series</div>
   <h1 class="c-hero__title">Far Side</h1>
+  {% include au-palette-strip.html %}
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
     <span class="c-hero__byline-text">Sam Bell · Moon (2009) · ongoing</span>

--- a/series/tuning-the-devil/index.html
+++ b/series/tuning-the-devil/index.html
@@ -21,6 +21,7 @@ collection_desc: "一九三五年南方小镇。一位藏着天使身份的司�
 
   <div class="c-hero__eyebrow">AU Story · Series</div>
   <h1 class="c-hero__title">Tuning the Devil</h1>
+  {% include au-palette-strip.html %}
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
     <span class="c-hero__byline-text">Wild Bill Wharton · The Green Mile · ongoing</span>

--- a/series/you-are-my-fact/index.html
+++ b/series/you-are-my-fact/index.html
@@ -17,6 +17,7 @@ series_name: "You Are My Fact"
 
   <div class="c-hero__eyebrow">AU Story · Series</div>
   <h1 class="c-hero__title">You Are My Fact</h1>
+  {% include au-palette-strip.html %}
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
     <span class="c-hero__byline-text">Leonard Shelby · Memento (2000) · ongoing</span>

--- a/series/zaphod-au/index.html
+++ b/series/zaphod-au/index.html
@@ -21,6 +21,7 @@ collection_desc: "银河系最混乱的总统，和那个在他背后悄悄校�
 
   <div class="c-hero__eyebrow">AU Story · Series</div>
   <h1 class="c-hero__title">Don't Panic, <em>Baby Doll</em></h1>
+  {% include au-palette-strip.html %}
   <div class="c-hero__byline">
     <span class="c-hero__byline-rule"></span>
     <span class="c-hero__byline-text">Zaphod Beeblebrox · Hitchhiker's Guide · ongoing</span>


### PR DESCRIPTION
## 改动

**① 宝丽来卡片（全站）**
- 新增 `_sass/5-components/_polaroid.scss` — 覆盖 `.c-post` 成奶白相纸，轻微歪斜、悬停摆正抬起。
- `_includes/main.scss` 在 `index-post` 之后导入 `polaroid`。

**② AU 色卡 → 电影胶片**
- 覆盖 `_includes/au-palette-style.html` — 整页专属深色主题 + 强调色背光，新增 `.au-strip` / `.au-tag` 胶片质感。
- 新增 `_includes/au-palette-strip.html` — 按 `series_name` 自动取色，不在配色表的系列不渲染。
- `_layouts/series.html` 删除旧 `.au-card` 小卡块。
- 7 个 `series/*/index.html` 标题正下方加 `{% include au-palette-strip.html %}`。

## 两处说明

1. **仓库实有 7 个系列**（非任务里写的 8）。「The One Who Remembers」在本仓库不存在，故无第 8 个文件可改 —— 与任务「它不在配色表、include 自动不渲染」一致，无副作用。
2. **补了任务漏掉的数据**：新版样式把 `--c-ink`/`--c-muted` 映射到 `p.text`/`p.muted`，但 `au_palettes.yml` 原本没有这两个键，照原样会生成空值字色。已为 7 个配色各补一组按冷暖调过的 `text`/`muted`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBNZP35hVDFfqNq4JAwY6b)_