### PR TITLE
适配代码块明暗主题，并让章节页色卡居中

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -31,7 +31,10 @@ layout: home
         </span>
       </a>
       {% endif %}
-      {% include au-palette-strip.html %}
+      {%- assign pal_key = page.series_name | default: page.series -%}
+      {%- if site.data.au_palettes[pal_key] -%}
+      <div class="c-chapter-palette">{% include au-palette-strip.html %}</div>
+      {%- endif -%}
       <header class="c-article__header">
         <h1 class="c-article__title">{{page.title}}</h1>
         <div class="c-article__date">

--- a/_sass/2-generic/_syntax-highlighting.scss
+++ b/_sass/2-generic/_syntax-highlighting.scss
@@ -3,10 +3,10 @@
 */
 
 .highlight {
-  background: #f7f7f7;
+  background: var(--c-line);
 
   .highlighter-rouge & {
-    background: #eef;
+    background: var(--c-line);
   }
 
   .c     { color: #998; font-style: italic } // Comment

--- a/_sass/3-elements/_code.scss
+++ b/_sass/3-elements/_code.scss
@@ -9,10 +9,19 @@ code {
   word-break: break-all;
   font-family: Courier, monospace;
   font-size: 14px;
-  background-color: #f7f7f7;
+  // 跟随明暗主题：底色用会随明暗翻转的 line 令牌，文字用 ink，始终高对比
+  color: var(--c-ink);
+  background-color: var(--c-line-strong);
+  border-radius: 3px;
 }
 
 p code,
 li code {
   padding: 3px 5px;
+}
+
+// pre 块内部的 code 不再叠一层底，避免双重背景
+pre code {
+  padding: 0;
+  background-color: transparent;
 }

--- a/_sass/3-elements/_pre.scss
+++ b/_sass/3-elements/_pre.scss
@@ -10,4 +10,9 @@ pre {
   word-wrap: break-word;
   word-break: break-all;
   font-family: Courier, monospace;
+  // 跟随明暗主题
+  color: var(--c-ink-soft);
+  background-color: var(--c-line);
+  border: 1px solid var(--c-line-strong);
+  border-radius: 6px;
 }

--- a/_sass/5-components/_extras.scss
+++ b/_sass/5-components/_extras.scss
@@ -90,6 +90,13 @@
   }
 }
 
+/* 章节页：返回卡片下方的胶片色卡单独成行并居中 */
+.c-chapter-palette {
+  display: flex;
+  justify-content: center;
+  margin: 0 0 28px;
+}
+
 .c-chapter-return__arrow {
   font-size: 18px;
   color: $accent;


### PR DESCRIPTION
## 改动

### 1. 代码块明暗主题适配
内联 `code` / `pre` / `.highlight` 原本写死浅色底（`#f7f7f7`、`#eef`）且无文字色，暗色模式下浅底浅字几乎不可读。改用随明暗翻转的 `--c-line` / `--c-line-strong` 令牌做底、`--c-ink` 令牌做字，浅色 / 暗色 / AU 系列专属配色页均自动适配；`pre` 内的 `code` 取消背景避免双重底。

### 2. 章节页色卡居中
章节页返回卡片下方的胶片色卡用 `.c-chapter-palette` 包裹并居中，不再与返回卡片挤在同一行。系列首页色卡不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013vFMnyucLcA6QeUn5QJmB1)_