### PR TITLE
Redesign theme picker as full-screen film-strip overlay

### DIFF
--- a/_sass/5-components/_theme-picker.scss
+++ b/_sass/5-components/_theme-picker.scss
@@ -143,8 +143,18 @@
 
 .c-palette-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 0.5rem;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.4rem;
+  max-height: 13rem;  // ~4 rows visible; scroll for the rest
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 0.125rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--c-line-strong) transparent;
+
+  &::-webkit-scrollbar       { width: 4px; }
+  &::-webkit-scrollbar-track { background: transparent; }
+  &::-webkit-scrollbar-thumb { background: var(--c-line-strong); border-radius: 99px; }
 }
 
 .c-palette-swatch {
@@ -185,13 +195,14 @@
 
 .c-palette-swatch__name {
   display: block;
-  font-size: 0.58rem;
+  font-size: 0.57rem;
   color: var(--c-muted);
   margin-top: 0.2rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-family: 'Noto Serif SC', serif;
+  font-family: 'EB Garamond', serif;
+  font-style: italic;
   line-height: 1.2;
 }
 

--- a/_sass/5-components/_theme-picker.scss
+++ b/_sass/5-components/_theme-picker.scss
@@ -1,8 +1,8 @@
 /* ============================
-   THEME PICKER
+   THEME PICKER — Film Strip Overlay
 ============================ */
 
-// ── Trigger button (lives in the header, next to the dark mode toggle) ──────
+// ── Trigger button (in header, next to dark mode toggle) ──────────────────────
 
 .c-palette-trigger {
   flex-shrink: 0;
@@ -35,60 +35,79 @@
   }
 }
 
-// ── Sliding panel ────────────────────────────────────────────────────────────
+// ── Full-screen overlay ────────────────────────────────────────────────────────
 
-.c-palette-panel {
+.c-palette-overlay {
   position: fixed;
-  bottom: 0;
-  right: 0;
-  z-index: 100;
-  width: 21rem;
-  max-width: 100vw;
-  background: var(--c-paper);
-  border-top: 1px solid var(--c-line-strong);
-  border-left: 1px solid var(--c-line-strong);
-  border-radius: 0.875rem 0 0 0;
-  box-shadow: -4px -4px 28px rgba(var(--rgb-shadow), 0.13);
-  transform: translateY(calc(100% + 4px));
-  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  will-change: transform;
+  inset: 0;
+  z-index: 300;
+  background: rgba(0, 0, 0, 0.72);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.28s ease, visibility 0.28s ease;
 
   &.is-open {
-    transform: translateY(0);
+    opacity: 1;
+    visibility: visible;
   }
 }
 
-.c-palette-panel__inner {
-  padding: 1.125rem 1.125rem 1rem;
+// ── Modal container ────────────────────────────────────────────────────────────
+
+.c-palette-modal {
+  background: var(--c-paper);
+  border-radius: 1rem;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.48), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  width: 100%;
+  max-width: 58rem;
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  transform: translateY(24px) scale(0.97);
+  transition: transform 0.28s cubic-bezier(0.34, 1.36, 0.64, 1);
+
+  .is-open & {
+    transform: translateY(0) scale(1);
+  }
 }
 
-.c-palette-panel__header {
+.c-palette-modal__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 1rem;
+  padding: 1.125rem 1.375rem 0.9rem;
+  border-bottom: 1px solid var(--c-line);
+  flex-shrink: 0;
 }
 
-.c-palette-panel__title {
-  font-size: 0.8125rem;
-  font-weight: 600;
+.c-palette-modal__title {
+  font-family: 'EB Garamond', serif;
+  font-style: italic;
+  font-size: 1.0625rem;
   color: var(--c-ink);
-  letter-spacing: 0.03em;
+  letter-spacing: 0.02em;
 }
 
-.c-palette-panel__close {
-  width: 1.625rem;
-  height: 1.625rem;
+.c-palette-modal__close {
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
   border: none;
   background: var(--c-line);
   color: var(--c-muted);
-  font-size: 0.7rem;
+  font-size: 0.75rem;
   line-height: 1;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   transition: background 0.15s, color 0.15s;
 
   &:hover {
@@ -97,121 +116,127 @@
   }
 }
 
-.c-palette-panel__reset {
-  display: block;
-  width: 100%;
-  margin-top: 0.125rem;
-  padding: 0.45rem 0.75rem;
-  background: none;
-  border: 1px solid var(--c-line-strong);
-  border-radius: 0.375rem;
-  color: var(--c-muted);
-  font-size: 0.725rem;
-  cursor: pointer;
-  transition: border-color 0.15s, color 0.15s;
-  text-align: center;
+// ── Scrollable body ────────────────────────────────────────────────────────────
 
-  &:hover {
-    border-color: var(--c-accent);
-    color: var(--c-accent);
-  }
-}
-
-// ── Section ───────────────────────────────────────────────────────────────────
-
-.c-palette-section {
-  margin-bottom: 0.875rem;
-}
-
-.c-palette-section__label {
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--c-muted);
-  margin: 0 0 0.55rem;
-}
-
-.c-palette-section__hint {
-  font-size: 0.65rem;
-  color: var(--c-muted-soft);
-  margin: 0.375rem 0 0;
-  line-height: 1.45;
-}
-
-// ── Swatch grid ───────────────────────────────────────────────────────────────
-
-.c-palette-grid {
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 0.4rem;
-  max-height: 13rem;  // ~4 rows visible; scroll for the rest
+.c-palette-modal__body {
+  flex: 1 1 auto;
   overflow-y: auto;
-  overflow-x: hidden;
-  padding-right: 0.125rem;
+  padding: 1.25rem 1.375rem;
   scrollbar-width: thin;
   scrollbar-color: var(--c-line-strong) transparent;
 
-  &::-webkit-scrollbar       { width: 4px; }
+  &::-webkit-scrollbar       { width: 5px; }
   &::-webkit-scrollbar-track { background: transparent; }
   &::-webkit-scrollbar-thumb { background: var(--c-line-strong); border-radius: 99px; }
 }
 
-.c-palette-swatch {
-  background: none;
+// ── Film strip card grid ───────────────────────────────────────────────────────
+
+.c-palette-cards {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.75rem;
+
+  @media (max-width: 900px) { grid-template-columns: repeat(5, 1fr); }
+  @media (max-width: 640px) { grid-template-columns: repeat(4, 1fr); }
+  @media (max-width: 440px) { grid-template-columns: repeat(3, 1fr); gap: 0.5rem; }
+}
+
+// ── Individual film strip card ─────────────────────────────────────────────────
+
+.c-palette-card {
   border: none;
   padding: 0;
   cursor: pointer;
   text-align: center;
-  transition: transform 0.15s;
-
-  &:hover { transform: scale(1.07); }
-}
-
-// The colour chip: diagonal split — bg colour top-left, accent bottom-right
-.c-palette-swatch__chip {
-  display: block;
-  width: 100%;
-  aspect-ratio: 1;
-  border-radius: 0.4rem;
+  display: flex;
+  flex-direction: column;
+  border-radius: 0.5rem;
   overflow: hidden;
-  position: relative;
-  background-color: var(--sw-bg);
-  border: 1px solid rgba(0, 0, 0, 0.07);
-  transition: box-shadow 0.18s;
+  background-color: var(--card-bg);
+  box-shadow: inset 0 0 0 1.5px rgba(255, 255, 255, 0.08);
+  transition: box-shadow 0.2s ease, transform 0.16s ease;
 
-  &::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background-color: var(--sw-ac);
-    clip-path: polygon(100% 35%, 100% 100%, 0% 100%);
+  &:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 0 0 2px var(--card-ac), 0 8px 24px rgba(0, 0, 0, 0.45);
+  }
+
+  &.is-active {
+    box-shadow: 0 0 0 2.5px var(--card-ac), 0 8px 24px rgba(0, 0, 0, 0.55);
   }
 }
 
-.c-palette-swatch.is-active .c-palette-swatch__chip {
-  box-shadow: 0 0 0 2px var(--c-paper), 0 0 0 3.5px var(--c-accent);
+// Film perforations row
+.c-palette-card__perfs {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  padding: 0.3rem 0.25rem;
+  flex-shrink: 0;
+
+  i {
+    display: block;
+    width: 5px;
+    height: 3.5px;
+    border-radius: 1px;
+    background: rgba(255, 255, 255, 0.17);
+    flex-shrink: 0;
+  }
 }
 
-.c-palette-swatch__name {
+// Card body (dot + name)
+.c-palette-card__body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0.375rem 0.5rem;
+  flex: 1;
+}
+
+.c-palette-card__dot {
   display: block;
-  font-size: 0.57rem;
-  color: var(--c-muted);
-  margin-top: 0.2rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background-color: var(--card-ac);
+  flex-shrink: 0;
+}
+
+.c-palette-card__name {
+  display: block;
   font-family: 'EB Garamond', serif;
   font-style: italic;
-  line-height: 1.2;
+  font-size: 0.72rem;
+  color: var(--card-ac);
+  text-align: center;
+  line-height: 1.25;
+  word-break: break-word;
+  hyphens: auto;
+  padding: 0 0.125rem;
 }
 
-// ── Custom hue section ─────────────────────────────────────────────────────────
+// ── Footer bar (custom hue + reset) ───────────────────────────────────────────
 
-.c-palette-custom {
+.c-palette-modal__footer {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
+  gap: 0.75rem;
+  padding: 0.875rem 1.375rem 1.125rem;
+  border-top: 1px solid var(--c-line);
+  flex-shrink: 0;
+}
+
+.c-palette-footer__label {
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--c-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .c-palette-hue {
@@ -233,33 +258,49 @@
 
   &::-webkit-slider-thumb {
     -webkit-appearance: none;
-    width: 1.0625rem;
-    height: 1.0625rem;
+    width: 1.125rem;
+    height: 1.125rem;
     border-radius: 50%;
     background: var(--c-paper);
     border: 2.5px solid var(--c-accent);
     box-shadow: 0 1px 5px rgba(var(--rgb-shadow), 0.22);
     cursor: pointer;
-    transition: border-color 0.15s;
   }
 
   &::-moz-range-thumb {
-    width: 1.0625rem;
-    height: 1.0625rem;
+    width: 1.125rem;
+    height: 1.125rem;
     border-radius: 50%;
     background: var(--c-paper);
     border: 2.5px solid var(--c-accent);
     box-shadow: 0 1px 5px rgba(var(--rgb-shadow), 0.22);
     cursor: pointer;
-    transition: border-color 0.15s;
   }
 }
 
 .c-palette-custom__preview {
   flex-shrink: 0;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.375rem;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  border: 2px solid rgba(0, 0, 0, 0.1);
   transition: background-color 0.1s;
+}
+
+.c-palette-panel__reset {
+  flex-shrink: 0;
+  padding: 0.4rem 0.8rem;
+  background: none;
+  border: 1px solid var(--c-line-strong);
+  border-radius: 0.375rem;
+  color: var(--c-muted);
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+
+  &:hover {
+    border-color: var(--c-accent);
+    color: var(--c-accent);
+  }
 }

--- a/js/theme-picker.js
+++ b/js/theme-picker.js
@@ -202,50 +202,52 @@
   }
 
   // ── UI ────────────────────────────────────────────────────────────────────
-  // Trigger lives in header.html; we only build the panel here.
+  // Trigger lives in header.html; we only build the overlay here.
+
+  var PERFS = '<i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>';
 
   function buildUI() {
     var trigger = document.getElementById('js-palette-trigger');
 
-    var panel = document.createElement('div');
-    panel.className = 'c-palette-panel';
-    panel.id = 'js-palette-panel';
-    panel.setAttribute('role', 'dialog');
-    panel.setAttribute('aria-label', '配色主题');
-    panel.setAttribute('aria-hidden', 'true');
+    var overlay = document.createElement('div');
+    overlay.className = 'c-palette-overlay';
+    overlay.id = 'js-palette-overlay';
+    overlay.setAttribute('aria-hidden', 'true');
 
-    // Swatch grid — dark bg + accent chip so it reads like the gallery
-    var grid = '';
+    // Film strip cards — one per character theme
+    var cards = '';
     THEMES.forEach(function (t) {
-      grid += '<button class="c-palette-swatch" data-theme-id="' + t.id + '" aria-label="' + t.name + '">' +
-        '<span class="c-palette-swatch__chip" style="--sw-bg:' + t.bg + ';--sw-ac:' + t.accent + '"></span>' +
-        '<span class="c-palette-swatch__name">' + t.name + '</span>' +
+      cards +=
+        '<button class="c-palette-card" data-theme-id="' + t.id + '" aria-label="' + t.name + '"' +
+          ' style="--card-bg:' + t.bg + ';--card-ac:' + t.accent + '">' +
+          '<span class="c-palette-card__perfs">' + PERFS + '</span>' +
+          '<span class="c-palette-card__body">' +
+            '<span class="c-palette-card__dot"></span>' +
+            '<span class="c-palette-card__name">' + t.name + '</span>' +
+          '</span>' +
+          '<span class="c-palette-card__perfs">' + PERFS + '</span>' +
         '</button>';
     });
 
-    panel.innerHTML =
-      '<div class="c-palette-panel__inner">' +
-        '<div class="c-palette-panel__header">' +
-          '<span class="c-palette-panel__title">换个心情</span>' +
-          '<button class="c-palette-panel__close" id="js-palette-close" aria-label="关闭">✕</button>' +
+    overlay.innerHTML =
+      '<div class="c-palette-modal" role="dialog" aria-label="配色主题 · 换个心情">' +
+        '<div class="c-palette-modal__header">' +
+          '<span class="c-palette-modal__title">换个心情 · Many Faces</span>' +
+          '<button class="c-palette-modal__close" id="js-palette-close" aria-label="关闭">✕</button>' +
         '</div>' +
-        '<section class="c-palette-section">' +
-          '<p class="c-palette-section__label">Many Faces · 角色配色</p>' +
-          '<div class="c-palette-grid" id="js-palette-grid">' + grid + '</div>' +
-        '</section>' +
-        '<section class="c-palette-section">' +
-          '<p class="c-palette-section__label">自定义强调色</p>' +
-          '<div class="c-palette-custom">' +
-            '<input type="range" class="c-palette-hue" id="js-palette-hue" min="0" max="359" value="0" aria-label="色相">' +
-            '<div class="c-palette-custom__preview" id="js-palette-preview"></div>' +
-          '</div>' +
-          '<p class="c-palette-section__hint">仅调整强调色，背景保持中性</p>' +
-        '</section>' +
-        '<button class="c-palette-panel__reset" id="js-palette-reset">还原默认配色</button>' +
+        '<div class="c-palette-modal__body">' +
+          '<div class="c-palette-cards" id="js-palette-grid">' + cards + '</div>' +
+        '</div>' +
+        '<div class="c-palette-modal__footer">' +
+          '<span class="c-palette-footer__label">自定义色</span>' +
+          '<input type="range" class="c-palette-hue" id="js-palette-hue" min="0" max="359" value="0" aria-label="自定义色相">' +
+          '<div class="c-palette-custom__preview" id="js-palette-preview"></div>' +
+          '<button class="c-palette-panel__reset" id="js-palette-reset">还原默认</button>' +
+        '</div>' +
       '</div>';
 
-    document.body.appendChild(panel);
-    return { trigger: trigger, panel: panel };
+    document.body.appendChild(overlay);
+    return { trigger: trigger, overlay: overlay };
   }
 
   function updateHuePreview(hue) {
@@ -262,29 +264,29 @@
     });
   }
 
-  function initEvents(trigger, panel) {
+  function initEvents(trigger, overlay) {
     var open = false;
 
-    function openPanel()  {
+    function openOverlay() {
       open = true;
-      panel.classList.add('is-open');
-      panel.setAttribute('aria-hidden', 'false');
+      overlay.classList.add('is-open');
+      overlay.setAttribute('aria-hidden', 'false');
       trigger.setAttribute('aria-expanded', 'true');
+      document.body.style.overflow = 'hidden';
       updateSwatchStates();
     }
-    function closePanel() {
+    function closeOverlay() {
       open = false;
-      panel.classList.remove('is-open');
-      panel.setAttribute('aria-hidden', 'true');
+      overlay.classList.remove('is-open');
+      overlay.setAttribute('aria-hidden', 'true');
       trigger.setAttribute('aria-expanded', 'false');
+      document.body.style.overflow = '';
     }
 
-    trigger.addEventListener('click', function (e) { e.stopPropagation(); open ? closePanel() : openPanel(); });
-    document.getElementById('js-palette-close').addEventListener('click', closePanel);
-    document.addEventListener('click', function (e) {
-      if (open && !panel.contains(e.target) && e.target !== trigger) closePanel();
-    });
-    document.addEventListener('keydown', function (e) { if (e.key === 'Escape' && open) closePanel(); });
+    trigger.addEventListener('click', function (e) { e.stopPropagation(); open ? closeOverlay() : openOverlay(); });
+    document.getElementById('js-palette-close').addEventListener('click', closeOverlay);
+    overlay.addEventListener('click', function (e) { if (e.target === overlay) closeOverlay(); });
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape' && open) closeOverlay(); });
 
     document.getElementById('js-palette-grid').addEventListener('click', function (e) {
       var btn = e.target.closest('[data-theme-id]');
@@ -328,7 +330,7 @@
     } catch (e) {}
 
     var ui = buildUI();
-    initEvents(ui.trigger, ui.panel);
+    initEvents(ui.trigger, ui.overlay);
   }
 
   if (document.readyState === 'loading') {

--- a/js/theme-picker.js
+++ b/js/theme-picker.js
@@ -9,158 +9,113 @@
     return parseInt(hex.slice(1,3),16)+', '+parseInt(hex.slice(3,5),16)+', '+parseInt(hex.slice(5,7),16);
   }
 
-  function hslToHex(h, s, l) {
-    s /= 100; l /= 100;
-    var a = s * Math.min(l, 1 - l);
-    function f(n) {
-      var k = (n + h / 30) % 12;
-      var c = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-      return Math.round(255 * c).toString(16).padStart(2, '0');
-    }
-    return '#' + f(0) + f(8) + f(4);
+  // Mirrors CSS color-mix(in srgb, hex1 pct%, hex2)
+  function colorMix(hex1, pct, hex2) {
+    var p=pct/100, q=1-p;
+    var r1=parseInt(hex1.slice(1,3),16), g1=parseInt(hex1.slice(3,5),16), b1=parseInt(hex1.slice(5,7),16);
+    var r2=parseInt(hex2.slice(1,3),16), g2=parseInt(hex2.slice(3,5),16), b2=parseInt(hex2.slice(5,7),16);
+    function m(a,b){return Math.round(a*p+b*q).toString(16).padStart(2,'0');}
+    return '#'+m(r1,r2)+m(g1,g2)+m(b1,b2);
   }
 
-  // ── Theme definitions ────────────────────────────────────────────────────
-  // Each theme has light + dark variants covering all CSS custom properties.
+  function hslToHex(h, s, l) {
+    s/=100; l/=100;
+    var a=s*Math.min(l,1-l);
+    function f(n){var k=(n+h/30)%12,c=l-a*Math.max(Math.min(k-3,9-k,1),-1);return Math.round(255*c).toString(16).padStart(2,'0');}
+    return '#'+f(0)+f(8)+f(4);
+  }
+
+  // ── Theme definitions — Many Faces of Sam ────────────────────────────────
+  // accent/bg/text/muted pulled directly from the gallery's palette data.
 
   var THEMES = [
-    {
-      id: 'rose', name: '冬日玫瑰', mood: '暖 · 默认',
-      light: {
-        bg:'#f7f3ec', bgSoft:'#fbf8f1', paper:'#ffffff',
-        ink:'#1f1d1a', inkSoft:'#3d3833', muted:'#8a8074', mutedSoft:'#b6ac9d',
-        line:'#e6dfd2', lineStrong:'#cfc6b4',
-        accent:'#b85c5c', accentSoft:'#d3938b', accentDark:'#9c4848',
-        statusRed:'#c0594a', statusGreen:'#6b8a5b'
-      },
-      dark: {
-        bg:'#1a1815', bgSoft:'#211f1a', paper:'#24211d',
-        ink:'#efe8da', inkSoft:'#c8c0b1', muted:'#948a7c', mutedSoft:'#6e665b',
-        line:'#322e28', lineStrong:'#4a443c',
-        accent:'#d97978', accentSoft:'#b06564', accentDark:'#f08e8d',
-        statusRed:'#d97978', statusGreen:'#84a06f'
-      }
-    },
-    {
-      id: 'rain', name: '烟雨青瓦', mood: '凉 · 沉静',
-      light: {
-        bg:'#edf1f6', bgSoft:'#f2f5f9', paper:'#ffffff',
-        ink:'#1a2028', inkSoft:'#2c3848', muted:'#6a7888', mutedSoft:'#9aa8b8',
-        line:'#ccd4e0', lineStrong:'#b4c0d0',
-        accent:'#4e7296', accentSoft:'#7a98b8', accentDark:'#365678',
-        statusRed:'#b05050', statusGreen:'#5a8450'
-      },
-      dark: {
-        bg:'#141820', bgSoft:'#1a2028', paper:'#1e242e',
-        ink:'#dce8f4', inkSoft:'#a8b8cc', muted:'#6878a0', mutedSoft:'#4a5878',
-        line:'#242c3c', lineStrong:'#344460',
-        accent:'#7898c0', accentSoft:'#5878a0', accentDark:'#96b4d8',
-        statusRed:'#c06868', statusGreen:'#6a9460'
-      }
-    },
-    {
-      id: 'amber', name: '暮色琥珀', mood: '暖 · 活泼',
-      light: {
-        bg:'#fdf5e8', bgSoft:'#fef9f0', paper:'#ffffff',
-        ink:'#241a10', inkSoft:'#483420', muted:'#988060', mutedSoft:'#c4aa88',
-        line:'#eaddc4', lineStrong:'#d8c8a8',
-        accent:'#c07828', accentSoft:'#d89a58', accentDark:'#985a18',
-        statusRed:'#c04a3a', statusGreen:'#6a8848'
-      },
-      dark: {
-        bg:'#1e1710', bgSoft:'#261e14', paper:'#2a2018',
-        ink:'#f0e4cc', inkSoft:'#d0b898', muted:'#a08858', mutedSoft:'#706040',
-        line:'#382c1c', lineStrong:'#504030',
-        accent:'#d89050', accentSoft:'#a87038', accentDark:'#f0a870',
-        statusRed:'#d06050', statusGreen:'#80a060'
-      }
-    },
-    {
-      id: 'moss', name: '竹影苔痕', mood: '自然 · 宁静',
-      light: {
-        bg:'#eff4ec', bgSoft:'#f4f8f2', paper:'#ffffff',
-        ink:'#1a2018', inkSoft:'#2e3c2c', muted:'#6a8060', mutedSoft:'#a0b498',
-        line:'#d0e0c8', lineStrong:'#b8ccac',
-        accent:'#5a7c48', accentSoft:'#88a870', accentDark:'#446038',
-        statusRed:'#b05044', statusGreen:'#4a7a44'
-      },
-      dark: {
-        bg:'#151a12', bgSoft:'#1c2218', paper:'#202818',
-        ink:'#e0edd8', inkSoft:'#b0c8a8', muted:'#789068', mutedSoft:'#506848',
-        line:'#283020', lineStrong:'#384830',
-        accent:'#88a868', accentSoft:'#688050', accentDark:'#a8c880',
-        statusRed:'#c06858', statusGreen:'#70a060'
-      }
-    },
-    {
-      id: 'moonlit', name: '月光书房', mood: '冷 · 专注',
-      light: {
-        bg:'#f0f2f8', bgSoft:'#f5f6fa', paper:'#ffffff',
-        ink:'#181c2c', inkSoft:'#2c3448', muted:'#6870a0', mutedSoft:'#9aa4c8',
-        line:'#ccd0e4', lineStrong:'#b4bcdc',
-        accent:'#4a608c', accentSoft:'#7a90b8', accentDark:'#344870',
-        statusRed:'#a85060', statusGreen:'#5a806a'
-      },
-      dark: {
-        bg:'#14161e', bgSoft:'#1a1c28', paper:'#1e2230',
-        ink:'#dce0f4', inkSoft:'#a8b0cc', muted:'#6070a8', mutedSoft:'#404c78',
-        line:'#222840', lineStrong:'#303c58',
-        accent:'#8090c8', accentSoft:'#5a6aa8', accentDark:'#a0b0e4',
-        statusRed:'#c06878', statusGreen:'#6a8c7a'
-      }
-    },
-    {
-      id: 'lilac', name: '丁香晚霞', mood: '温柔 · 浪漫',
-      light: {
-        bg:'#f4f0f8', bgSoft:'#f8f5fc', paper:'#ffffff',
-        ink:'#1e1828', inkSoft:'#382c48', muted:'#8070a0', mutedSoft:'#b4a4cc',
-        line:'#e0d4f0', lineStrong:'#ccc0e0',
-        accent:'#8860ac', accentSoft:'#b090d4', accentDark:'#6c4890',
-        statusRed:'#b05878', statusGreen:'#6a8864'
-      },
-      dark: {
-        bg:'#1a1620', bgSoft:'#211c28', paper:'#262030',
-        ink:'#eee8f8', inkSoft:'#c8b8e0', muted:'#9880c0', mutedSoft:'#685888',
-        line:'#2c2438', lineStrong:'#403450',
-        accent:'#aa88d8', accentSoft:'#8868b8', accentDark:'#c4a4f0',
-        statusRed:'#d07888', statusGreen:'#80a078'
-      }
-    },
-    {
-      id: 'vermilion', name: '朱砂流丹', mood: '热烈 · 张扬',
-      light: {
-        bg:'#fef2ef', bgSoft:'#fff5f3', paper:'#ffffff',
-        ink:'#241410', inkSoft:'#4a2820', muted:'#a06858', mutedSoft:'#c8a090',
-        line:'#f0d8d0', lineStrong:'#e0c0b4',
-        accent:'#c44030', accentSoft:'#e07860', accentDark:'#a82818',
-        statusRed:'#c44030', statusGreen:'#5a8050'
-      },
-      dark: {
-        bg:'#201410', bgSoft:'#281a14', paper:'#2c1e18',
-        ink:'#f4e4dc', inkSoft:'#d0b0a0', muted:'#b07860', mutedSoft:'#784c3c',
-        line:'#3c2018', lineStrong:'#542c20',
-        accent:'#e06050', accentSoft:'#b84030', accentDark:'#f87868',
-        statusRed:'#e06050', statusGreen:'#789060'
-      }
-    },
-    {
-      id: 'mono', name: '墨分五彩', mood: '极简 · 克制',
-      light: {
-        bg:'#f8f8f6', bgSoft:'#fafaf8', paper:'#ffffff',
-        ink:'#1a1a18', inkSoft:'#363632', muted:'#888880', mutedSoft:'#b8b8b0',
-        line:'#e4e4e0', lineStrong:'#d0d0c8',
-        accent:'#484840', accentSoft:'#7a7a70', accentDark:'#282820',
-        statusRed:'#a85048', statusGreen:'#5a7850'
-      },
-      dark: {
-        bg:'#1a1a18', bgSoft:'#222220', paper:'#282826',
-        ink:'#ecece8', inkSoft:'#c0c0b8', muted:'#909088', mutedSoft:'#606058',
-        line:'#2e2e2c', lineStrong:'#404040',
-        accent:'#a8a8a0', accentSoft:'#808078', accentDark:'#d0d0c8',
-        statusRed:'#c06858', statusGreen:'#70906a'
-      }
-    }
+    { id:'gary',     name:'Gary',       accent:'#cba14c', bg:'#14110d', text:'#ede2d0', muted:'#8a7558' },
+    { id:'kris',     name:'Kris',       accent:'#bc4d3a', bg:'#11161c', text:'#ece0d2', muted:'#62768d' },
+    { id:'matty',    name:'Matty',      accent:'#d49850', bg:'#171d24', text:'#ebe0cc', muted:'#7d7264' },
+    { id:'buck',     name:'Buck',       accent:'#b8c878', bg:'#1a2418', text:'#e8eed8', muted:'#7a8868' },
+    { id:'trent',    name:'Trent',      accent:'#79a7bd', bg:'#141c12', text:'#dce5ea', muted:'#7a7654' },
+    { id:'samuel',   name:'Samuel',     accent:'#c5402f', bg:'#211a0f', text:'#f0e2d4', muted:'#a08770' },
+    { id:'jerry',    name:'Jerry',      accent:'#d7a83c', bg:'#20120c', text:'#f0e0d0', muted:'#a07060' },
+    { id:'wildbill', name:'Wild Bill',  accent:'#b0803e', bg:'#1b1510', text:'#ece0d0', muted:'#93826a' },
+    { id:'guy',      name:'Guy',        accent:'#43b3bf', bg:'#0f161a', text:'#dfe7ea', muted:'#738088' },
+    { id:'knox',     name:'Knox',       accent:'#d94040', bg:'#1b1310', text:'#ede0e0', muted:'#8d6e62' },
+    { id:'pero',     name:'Pero',       accent:'#d49858', bg:'#1a1612', text:'#ede0cc', muted:'#8a7458' },
+    { id:'chuck',    name:'Chuck',      accent:'#de6e8e', bg:'#15182a', text:'#ede4d0', muted:'#8088a0' },
+    { id:'mercer',   name:'Mercer',     accent:'#e08a2e', bg:'#1a1410', text:'#ede0e6', muted:'#8d7462' },
+    { id:'crocker',  name:'Crocker',    accent:'#d8b25a', bg:'#161214', text:'#f0e3dc', muted:'#8d6278' },
+    { id:'zaphod',   name:'Zaphod',     accent:'#d4a82a', bg:'#0b0a12', text:'#e8e4d0', muted:'#8a7a48' },
+    { id:'brad',     name:'Brad',       accent:'#c9d84e', bg:'#1c2230', text:'#e8eadc', muted:'#7a8590' },
+    { id:'glenn',    name:'Glenn',      accent:'#b8d0e0', bg:'#1c2030', text:'#dce4ea', muted:'#7a8090' },
+    { id:'reston',   name:'Reston',     accent:'#d89858', bg:'#1f1814', text:'#ebe0cc', muted:'#8a7458' },
+    { id:'victor',   name:'Victor',     accent:'#d2a24a', bg:'#2a1820', text:'#f0e0d4', muted:'#9a7868' },
+    { id:'sambell',  name:'Sam Bell',   accent:'#7eb0d5', bg:'#162038', text:'#e8eef5', muted:'#6a85a3' },
+    { id:'goode',    name:'Goode',      accent:'#cc4436', bg:'#211910', text:'#ede4d4', muted:'#9a7e58' },
+    { id:'hammer',   name:'Hammer',     accent:'#4a87ee', bg:'#13151c', text:'#e7eaf2', muted:'#7c8aa6' },
+    { id:'kenny',    name:'Kenny',      accent:'#d08a45', bg:'#1c1e1f', text:'#f0e0d4', muted:'#627f8d' },
+    { id:'billy',    name:'Billy',      accent:'#d63a33', bg:'#281208', text:'#f5e6d0', muted:'#b07840' },
+    { id:'owen',     name:'Owen',       accent:'#35bfc9', bg:'#15282e', text:'#dce9ea', muted:'#75899a' },
+    { id:'johnmoon', name:'J. Moon',    accent:'#8fa0b0', bg:'#14181f', text:'#dce3ea', muted:'#62728d' },
+    { id:'varney',   name:'Varney',     accent:'#e6ecea', bg:'#1e1408', text:'#dceae5', muted:'#8d7a62' },
+    { id:'wayne',    name:'Wayne',      accent:'#c8a050', bg:'#1e2418', text:'#e8e4d0', muted:'#8a7a48' },
+    { id:'craig',    name:'Craig',      accent:'#c89060', bg:'#241a14', text:'#ede0d0', muted:'#a07858' },
+    { id:'munch',    name:'Munch',      accent:'#e23b2e', bg:'#14241a', text:'#eed9d8', muted:'#628d72' },
+    { id:'dixon',    name:'Dixon',      accent:'#e2622a', bg:'#241015', text:'#f5e6d3', muted:'#8d626d' },
+    { id:'eddie',    name:'Eddie',      accent:'#2e9fd4', bg:'#1a1f24', text:'#dce5ea', muted:'#7a8088' },
+    { id:'bush',     name:'G.W. Bush',  accent:'#c98a3e', bg:'#16181e', text:'#f1e3cb', muted:'#626d8d' },
+    { id:'klenz',    name:'Klenz.',     accent:'#d34338', bg:'#14241c', text:'#ede8d8', muted:'#8b7d4d' },
+    { id:'bryant',   name:'Bryant',     accent:'#c8783c', bg:'#1c1410', text:'#ede0d0', muted:'#8a6848' },
+    { id:'mrwolf',   name:'Mr. Wolf',   accent:'#dfb23c', bg:'#14161d', text:'#ede6d8', muted:'#7a7d8a' },
+    { id:'stoppard', name:'Stoppard',   accent:'#c7995a', bg:'#1a1f2c', text:'#ebe2d4', muted:'#7c8090' },
+    { id:'wilde',    name:'Wilde',      accent:'#cda24f', bg:'#15192a', text:'#ebe2d0', muted:'#7a7e90' },
+    { id:'future',   name:'Future',     accent:'#d460a0', bg:'#1a0e2a', text:'#ede0ec', muted:'#8868a0' },
   ];
+
+  // ── Color derivation — mirrors au-palette-style.html exactly ─────────────
+  // Light: accent-tinted warm cream base (via colorMix)
+  // Dark:  character's own deep bg + full-saturation accent
+
+  var LB   = '#f6f2ea';   // light base bg
+  var LBS  = '#faf6ef';   // light base bg-soft
+  var LP   = '#fdfbf6';   // light paper
+  var DTINT = '#1a1614';  // dark tint for lightening accent on light bg
+
+  function lightVars(p) {
+    var bg     = colorMix(p.accent, 18, LB);
+    var bgSoft = colorMix(p.accent, 12, LBS);
+    var paper  = colorMix(p.accent,  7, LP);
+    var accent = colorMix(p.accent, 70, DTINT);  // color-mix(accent, #1a1614 30%)
+    var acSoft = colorMix(p.accent, 78, DTINT);  // color-mix(accent, #1a1614 22%)
+    var acDark = colorMix(p.accent, 58, '#000000'); // color-mix(accent, #000 42%)
+    return {
+      '--c-bg': bg, '--c-bg-soft': bgSoft, '--c-paper': paper,
+      '--c-ink': '#2b2620', '--c-ink-soft': '#4a443c',
+      '--c-muted': '#847a6d', '--c-muted-soft': '#a59a8a',
+      '--c-line': 'rgba(0,0,0,.10)', '--c-line-strong': 'rgba(0,0,0,.16)',
+      '--c-accent': accent, '--c-accent-soft': acSoft, '--c-accent-dark': acDark,
+      '--c-status-red': '#c0594a', '--c-status-green': '#6b8a5b',
+      '--rgb-accent': hexToRgb(accent),
+      '--rgb-bg': hexToRgb(bg),
+      '--rgb-paper': hexToRgb(paper),
+      '--rgb-shadow': '43, 38, 32',
+      '--rgb-line-warm': hexToRgb(colorMix(p.accent, 14, '#d4c4b0'))
+    };
+  }
+
+  function darkVars(p) {
+    return {
+      '--c-bg': p.bg, '--c-bg-soft': p.bg, '--c-paper': p.bg,
+      '--c-ink': p.text, '--c-ink-soft': p.text,
+      '--c-muted': p.muted, '--c-muted-soft': p.muted,
+      '--c-line': 'rgba(255,255,255,.10)', '--c-line-strong': 'rgba(255,255,255,.20)',
+      '--c-accent': p.accent, '--c-accent-soft': p.accent, '--c-accent-dark': p.accent,
+      '--c-status-red': '#c06868', '--c-status-green': '#6a9460',
+      '--rgb-accent': hexToRgb(p.accent),
+      '--rgb-bg': hexToRgb(p.bg),
+      '--rgb-paper': hexToRgb(p.bg),
+      '--rgb-shadow': '0, 0, 0',
+      '--rgb-line-warm': hexToRgb(p.bg)
+    };
+  }
 
   var ALL_VARS = [
     '--c-bg','--c-bg-soft','--c-paper',
@@ -172,22 +127,6 @@
   ];
 
   // ── Apply helpers ─────────────────────────────────────────────────────────
-
-  function buildVars(p, dark) {
-    return {
-      '--c-bg': p.bg, '--c-bg-soft': p.bgSoft, '--c-paper': p.paper,
-      '--c-ink': p.ink, '--c-ink-soft': p.inkSoft,
-      '--c-muted': p.muted, '--c-muted-soft': p.mutedSoft,
-      '--c-line': p.line, '--c-line-strong': p.lineStrong,
-      '--c-accent': p.accent, '--c-accent-soft': p.accentSoft, '--c-accent-dark': p.accentDark,
-      '--c-status-red': p.statusRed, '--c-status-green': p.statusGreen,
-      '--rgb-accent': hexToRgb(p.accent),
-      '--rgb-bg': hexToRgb(p.bg),
-      '--rgb-paper': hexToRgb(p.paper),
-      '--rgb-shadow': dark ? '0, 0, 0' : hexToRgb(p.ink),
-      '--rgb-line-warm': hexToRgb(p.line)
-    };
-  }
 
   function applyVars(vars) {
     var root = document.documentElement;
@@ -206,6 +145,10 @@
     return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
   }
 
+  function buildVars(p) {
+    return isDark() ? darkVars(p) : lightVars(p);
+  }
+
   // ── State ─────────────────────────────────────────────────────────────────
 
   var currentState = null;
@@ -217,65 +160,49 @@
 
   function applyState(state) {
     if (!state) { clearVars(); return; }
-    var dark = isDark();
     if (state.type === 'preset') {
       var t = THEMES.filter(function (x) { return x.id === state.id; })[0];
       if (!t) { clearVars(); return; }
-      applyVars(buildVars(dark ? t.dark : t.light, dark));
+      applyVars(buildVars(t));
     } else if (state.type === 'custom') {
       applyCustomHue(state.hue, false);
     }
   }
 
   function applyCustomHue(hue, save) {
-    var dark = isDark();
-    var s = dark ? 58 : 52;
-    var l = dark ? 65 : 46;
-    var accent    = hslToHex(hue, s, l);
-    var accentSoft = dark
-      ? hslToHex(hue, Math.max(0, s - 12), Math.max(5, l - 14))
-      : hslToHex(hue, Math.max(0, s - 10), Math.min(95, l + 13));
-    var accentDark = dark
-      ? hslToHex(hue, Math.min(100, s + 5), Math.min(95, l + 15))
-      : hslToHex(hue, Math.min(100, s + 5), Math.max(5, l - 10));
-
+    var s = isDark() ? 62 : 58;
+    var l = isDark() ? 65 : 47;
+    // Neutral dark bg for custom hue in dark mode (the default dark)
+    var fakeTheme = {
+      accent: hslToHex(hue, s, l),
+      bg: '#1a1815', text: '#efe8da', muted: '#948a7c'
+    };
     clearVars();
-    var root = document.documentElement;
-    root.style.setProperty('--c-accent', accent);
-    root.style.setProperty('--c-accent-soft', accentSoft);
-    root.style.setProperty('--c-accent-dark', accentDark);
-    root.style.setProperty('--rgb-accent', hexToRgb(accent));
-    root.style.setProperty('--c-status-red', accent);
-
+    applyVars(buildVars(fakeTheme));
     if (save !== false) saveState({ type: 'custom', hue: hue });
   }
 
   // ── Dark mode observation ─────────────────────────────────────────────────
 
-  // Re-apply theme when light/dark mode switches
-  var observer = new MutationObserver(function (mutations) {
-    mutations.forEach(function (m) {
-      if (m.attributeName === 'data-theme') {
-        applyState(currentState);
-        if (hueSliderEl) updateHuePreview(parseInt(hueSliderEl.value, 10));
-      }
-    });
-  });
-  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+  var hueSliderEl = null;
+
+  function onModeChange() {
+    applyState(currentState);
+    if (hueSliderEl) updateHuePreview(parseInt(hueSliderEl.value, 10));
+  }
+
+  new MutationObserver(function (ms) {
+    ms.forEach(function (m) { if (m.attributeName === 'data-theme') onModeChange(); });
+  }).observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
 
   if (window.matchMedia) {
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function () {
-      if (!document.documentElement.getAttribute('data-theme')) {
-        applyState(currentState);
-        if (hueSliderEl) updateHuePreview(parseInt(hueSliderEl.value, 10));
-      }
+      if (!document.documentElement.getAttribute('data-theme')) onModeChange();
     });
   }
 
-  var hueSliderEl = null; // set after UI build
-
   // ── UI ────────────────────────────────────────────────────────────────────
-  // The trigger button lives in header.html; we only build the panel here.
+  // Trigger lives in header.html; we only build the panel here.
 
   function buildUI() {
     var trigger = document.getElementById('js-palette-trigger');
@@ -287,10 +214,11 @@
     panel.setAttribute('aria-label', '配色主题');
     panel.setAttribute('aria-hidden', 'true');
 
+    // Swatch grid — dark bg + accent chip so it reads like the gallery
     var grid = '';
     THEMES.forEach(function (t) {
-      grid += '<button class="c-palette-swatch" data-theme-id="' + t.id + '" title="' + t.mood + '" aria-label="' + t.name + '">' +
-        '<span class="c-palette-swatch__chip" style="--sw-bg:' + t.light.bg + ';--sw-ac:' + t.light.accent + '"></span>' +
+      grid += '<button class="c-palette-swatch" data-theme-id="' + t.id + '" aria-label="' + t.name + '">' +
+        '<span class="c-palette-swatch__chip" style="--sw-bg:' + t.bg + ';--sw-ac:' + t.accent + '"></span>' +
         '<span class="c-palette-swatch__name">' + t.name + '</span>' +
         '</button>';
     });
@@ -302,7 +230,7 @@
           '<button class="c-palette-panel__close" id="js-palette-close" aria-label="关闭">✕</button>' +
         '</div>' +
         '<section class="c-palette-section">' +
-          '<p class="c-palette-section__label">心情主题</p>' +
+          '<p class="c-palette-section__label">Many Faces · 角色配色</p>' +
           '<div class="c-palette-grid" id="js-palette-grid">' + grid + '</div>' +
         '</section>' +
         '<section class="c-palette-section">' +
@@ -323,8 +251,8 @@
   function updateHuePreview(hue) {
     var el = document.getElementById('js-palette-preview');
     if (!el) return;
-    var dark = isDark();
-    el.style.backgroundColor = 'hsl(' + hue + ',' + (dark ? 58 : 52) + '%,' + (dark ? 65 : 46) + '%)';
+    var s = isDark() ? 62 : 58, l = isDark() ? 65 : 47;
+    el.style.backgroundColor = 'hsl(' + hue + ',' + s + '%,' + l + '%)';
   }
 
   function updateSwatchStates() {
@@ -337,7 +265,7 @@
   function initEvents(trigger, panel) {
     var open = false;
 
-    function openPanel() {
+    function openPanel()  {
       open = true;
       panel.classList.add('is-open');
       panel.setAttribute('aria-hidden', 'false');
@@ -351,20 +279,12 @@
       trigger.setAttribute('aria-expanded', 'false');
     }
 
-    trigger.addEventListener('click', function (e) {
-      e.stopPropagation();
-      open ? closePanel() : openPanel();
-    });
-
+    trigger.addEventListener('click', function (e) { e.stopPropagation(); open ? closePanel() : openPanel(); });
     document.getElementById('js-palette-close').addEventListener('click', closePanel);
-
     document.addEventListener('click', function (e) {
       if (open && !panel.contains(e.target) && e.target !== trigger) closePanel();
     });
-
-    document.addEventListener('keydown', function (e) {
-      if (e.key === 'Escape' && open) closePanel();
-    });
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape' && open) closePanel(); });
 
     document.getElementById('js-palette-grid').addEventListener('click', function (e) {
       var btn = e.target.closest('[data-theme-id]');
@@ -373,16 +293,14 @@
       applyState(state);
       saveState(state);
       updateSwatchStates();
-      var slider = document.getElementById('js-palette-hue');
-      if (slider) { slider.value = 0; updateHuePreview(0); }
+      var sl = document.getElementById('js-palette-hue');
+      if (sl) { sl.value = 0; updateHuePreview(0); }
     });
 
     var hueSlider = document.getElementById('js-palette-hue');
     hueSliderEl = hueSlider;
 
-    if (currentState && currentState.type === 'custom') {
-      hueSlider.value = currentState.hue;
-    }
+    if (currentState && currentState.type === 'custom') hueSlider.value = currentState.hue;
     updateHuePreview(parseInt(hueSlider.value, 10));
 
     hueSlider.addEventListener('input', function () {


### PR DESCRIPTION
Replace the small bottom-right sliding panel with a near-full-screen overlay. Each of the 39 character palettes is now rendered as a portrait film-strip card with dark background, accent-colour dot, full name, and perforations top and bottom — matching the au-palette-strip aesthetic.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQ2KB8THn3pSvEfbAUzeFn)_