### PR TITLE
Redesign theme picker as full-screen film-strip overlay

### DIFF
--- a/_sass/5-components/_theme-picker.scss
+++ b/_sass/5-components/_theme-picker.scss
@@ -1,8 +1,8 @@
 /* ============================
-   THEME PICKER
+   THEME PICKER — Film Strip Overlay
 ============================ */
 
-// ── Trigger button (lives in the header, next to the dark mode toggle) ──────
+// ── Trigger button (in header, next to dark mode toggle) ──────────────────────
 
 .c-palette-trigger {
   flex-shrink: 0;
@@ -35,60 +35,79 @@
   }
 }
 
-// ── Sliding panel ────────────────────────────────────────────────────────────
+// ── Full-screen overlay ────────────────────────────────────────────────────────
 
-.c-palette-panel {
+.c-palette-overlay {
   position: fixed;
-  bottom: 0;
-  right: 0;
-  z-index: 100;
-  width: 21rem;
-  max-width: 100vw;
-  background: var(--c-paper);
-  border-top: 1px solid var(--c-line-strong);
-  border-left: 1px solid var(--c-line-strong);
-  border-radius: 0.875rem 0 0 0;
-  box-shadow: -4px -4px 28px rgba(var(--rgb-shadow), 0.13);
-  transform: translateY(calc(100% + 4px));
-  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  will-change: transform;
+  inset: 0;
+  z-index: 300;
+  background: rgba(0, 0, 0, 0.72);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.28s ease, visibility 0.28s ease;
 
   &.is-open {
-    transform: translateY(0);
+    opacity: 1;
+    visibility: visible;
   }
 }
 
-.c-palette-panel__inner {
-  padding: 1.125rem 1.125rem 1rem;
+// ── Modal container ────────────────────────────────────────────────────────────
+
+.c-palette-modal {
+  background: var(--c-paper);
+  border-radius: 1rem;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.48), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  width: 100%;
+  max-width: 58rem;
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  transform: translateY(24px) scale(0.97);
+  transition: transform 0.28s cubic-bezier(0.34, 1.36, 0.64, 1);
+
+  .is-open & {
+    transform: translateY(0) scale(1);
+  }
 }
 
-.c-palette-panel__header {
+.c-palette-modal__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 1rem;
+  padding: 1.125rem 1.375rem 0.9rem;
+  border-bottom: 1px solid var(--c-line);
+  flex-shrink: 0;
 }
 
-.c-palette-panel__title {
-  font-size: 0.8125rem;
-  font-weight: 600;
+.c-palette-modal__title {
+  font-family: 'EB Garamond', serif;
+  font-style: italic;
+  font-size: 1.0625rem;
   color: var(--c-ink);
-  letter-spacing: 0.03em;
+  letter-spacing: 0.02em;
 }
 
-.c-palette-panel__close {
-  width: 1.625rem;
-  height: 1.625rem;
+.c-palette-modal__close {
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
   border: none;
   background: var(--c-line);
   color: var(--c-muted);
-  font-size: 0.7rem;
+  font-size: 0.75rem;
   line-height: 1;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   transition: background 0.15s, color 0.15s;
 
   &:hover {
@@ -97,121 +116,127 @@
   }
 }
 
-.c-palette-panel__reset {
-  display: block;
-  width: 100%;
-  margin-top: 0.125rem;
-  padding: 0.45rem 0.75rem;
-  background: none;
-  border: 1px solid var(--c-line-strong);
-  border-radius: 0.375rem;
-  color: var(--c-muted);
-  font-size: 0.725rem;
-  cursor: pointer;
-  transition: border-color 0.15s, color 0.15s;
-  text-align: center;
+// ── Scrollable body ────────────────────────────────────────────────────────────
 
-  &:hover {
-    border-color: var(--c-accent);
-    color: var(--c-accent);
-  }
-}
-
-// ── Section ───────────────────────────────────────────────────────────────────
-
-.c-palette-section {
-  margin-bottom: 0.875rem;
-}
-
-.c-palette-section__label {
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--c-muted);
-  margin: 0 0 0.55rem;
-}
-
-.c-palette-section__hint {
-  font-size: 0.65rem;
-  color: var(--c-muted-soft);
-  margin: 0.375rem 0 0;
-  line-height: 1.45;
-}
-
-// ── Swatch grid ───────────────────────────────────────────────────────────────
-
-.c-palette-grid {
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 0.4rem;
-  max-height: 13rem;  // ~4 rows visible; scroll for the rest
+.c-palette-modal__body {
+  flex: 1 1 auto;
   overflow-y: auto;
-  overflow-x: hidden;
-  padding-right: 0.125rem;
+  padding: 1.25rem 1.375rem;
   scrollbar-width: thin;
   scrollbar-color: var(--c-line-strong) transparent;
 
-  &::-webkit-scrollbar       { width: 4px; }
+  &::-webkit-scrollbar       { width: 5px; }
   &::-webkit-scrollbar-track { background: transparent; }
   &::-webkit-scrollbar-thumb { background: var(--c-line-strong); border-radius: 99px; }
 }
 
-.c-palette-swatch {
-  background: none;
+// ── Film strip card grid ───────────────────────────────────────────────────────
+
+.c-palette-cards {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.75rem;
+
+  @media (max-width: 900px) { grid-template-columns: repeat(5, 1fr); }
+  @media (max-width: 640px) { grid-template-columns: repeat(4, 1fr); }
+  @media (max-width: 440px) { grid-template-columns: repeat(3, 1fr); gap: 0.5rem; }
+}
+
+// ── Individual film strip card ─────────────────────────────────────────────────
+
+.c-palette-card {
   border: none;
   padding: 0;
   cursor: pointer;
   text-align: center;
-  transition: transform 0.15s;
-
-  &:hover { transform: scale(1.07); }
-}
-
-// The colour chip: diagonal split — bg colour top-left, accent bottom-right
-.c-palette-swatch__chip {
-  display: block;
-  width: 100%;
-  aspect-ratio: 1;
-  border-radius: 0.4rem;
+  display: flex;
+  flex-direction: column;
+  border-radius: 0.5rem;
   overflow: hidden;
-  position: relative;
-  background-color: var(--sw-bg);
-  border: 1px solid rgba(0, 0, 0, 0.07);
-  transition: box-shadow 0.18s;
+  background-color: var(--card-bg);
+  box-shadow: inset 0 0 0 1.5px rgba(255, 255, 255, 0.08);
+  transition: box-shadow 0.2s ease, transform 0.16s ease;
 
-  &::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background-color: var(--sw-ac);
-    clip-path: polygon(100% 35%, 100% 100%, 0% 100%);
+  &:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 0 0 2px var(--card-ac), 0 8px 24px rgba(0, 0, 0, 0.45);
+  }
+
+  &.is-active {
+    box-shadow: 0 0 0 2.5px var(--card-ac), 0 8px 24px rgba(0, 0, 0, 0.55);
   }
 }
 
-.c-palette-swatch.is-active .c-palette-swatch__chip {
-  box-shadow: 0 0 0 2px var(--c-paper), 0 0 0 3.5px var(--c-accent);
+// Film perforations row
+.c-palette-card__perfs {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  padding: 0.3rem 0.25rem;
+  flex-shrink: 0;
+
+  i {
+    display: block;
+    width: 5px;
+    height: 3.5px;
+    border-radius: 1px;
+    background: rgba(255, 255, 255, 0.17);
+    flex-shrink: 0;
+  }
 }
 
-.c-palette-swatch__name {
+// Card body (dot + name)
+.c-palette-card__body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0.375rem 0.5rem;
+  flex: 1;
+}
+
+.c-palette-card__dot {
   display: block;
-  font-size: 0.57rem;
-  color: var(--c-muted);
-  margin-top: 0.2rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background-color: var(--card-ac);
+  flex-shrink: 0;
+}
+
+.c-palette-card__name {
+  display: block;
   font-family: 'EB Garamond', serif;
   font-style: italic;
-  line-height: 1.2;
+  font-size: 0.72rem;
+  color: var(--card-ac);
+  text-align: center;
+  line-height: 1.25;
+  word-break: break-word;
+  hyphens: auto;
+  padding: 0 0.125rem;
 }
 
-// ── Custom hue section ─────────────────────────────────────────────────────────
+// ── Footer bar (custom hue + reset) ───────────────────────────────────────────
 
-.c-palette-custom {
+.c-palette-modal__footer {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
+  gap: 0.75rem;
+  padding: 0.875rem 1.375rem 1.125rem;
+  border-top: 1px solid var(--c-line);
+  flex-shrink: 0;
+}
+
+.c-palette-footer__label {
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--c-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .c-palette-hue {
@@ -233,33 +258,49 @@
 
   &::-webkit-slider-thumb {
     -webkit-appearance: none;
-    width: 1.0625rem;
-    height: 1.0625rem;
+    width: 1.125rem;
+    height: 1.125rem;
     border-radius: 50%;
     background: var(--c-paper);
     border: 2.5px solid var(--c-accent);
     box-shadow: 0 1px 5px rgba(var(--rgb-shadow), 0.22);
     cursor: pointer;
-    transition: border-color 0.15s;
   }
 
   &::-moz-range-thumb {
-    width: 1.0625rem;
-    height: 1.0625rem;
+    width: 1.125rem;
+    height: 1.125rem;
     border-radius: 50%;
     background: var(--c-paper);
     border: 2.5px solid var(--c-accent);
     box-shadow: 0 1px 5px rgba(var(--rgb-shadow), 0.22);
     cursor: pointer;
-    transition: border-color 0.15s;
   }
 }
 
 .c-palette-custom__preview {
   flex-shrink: 0;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.375rem;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  border: 2px solid rgba(0, 0, 0, 0.1);
   transition: background-color 0.1s;
+}
+
+.c-palette-panel__reset {
+  flex-shrink: 0;
+  padding: 0.4rem 0.8rem;
+  background: none;
+  border: 1px solid var(--c-line-strong);
+  border-radius: 0.375rem;
+  color: var(--c-muted);
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+
+  &:hover {
+    border-color: var(--c-accent);
+    color: var(--c-accent);
+  }
 }

--- a/js/theme-picker.js
+++ b/js/theme-picker.js
@@ -202,50 +202,52 @@
   }
 
   // ── UI ────────────────────────────────────────────────────────────────────
-  // Trigger lives in header.html; we only build the panel here.
+  // Trigger lives in header.html; we only build the overlay here.
+
+  var PERFS = '<i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>';
 
   function buildUI() {
     var trigger = document.getElementById('js-palette-trigger');
 
-    var panel = document.createElement('div');
-    panel.className = 'c-palette-panel';
-    panel.id = 'js-palette-panel';
-    panel.setAttribute('role', 'dialog');
-    panel.setAttribute('aria-label', '配色主题');
-    panel.setAttribute('aria-hidden', 'true');
+    var overlay = document.createElement('div');
+    overlay.className = 'c-palette-overlay';
+    overlay.id = 'js-palette-overlay';
+    overlay.setAttribute('aria-hidden', 'true');
 
-    // Swatch grid — dark bg + accent chip so it reads like the gallery
-    var grid = '';
+    // Film strip cards — one per character theme
+    var cards = '';
     THEMES.forEach(function (t) {
-      grid += '<button class="c-palette-swatch" data-theme-id="' + t.id + '" aria-label="' + t.name + '">' +
-        '<span class="c-palette-swatch__chip" style="--sw-bg:' + t.bg + ';--sw-ac:' + t.accent + '"></span>' +
-        '<span class="c-palette-swatch__name">' + t.name + '</span>' +
+      cards +=
+        '<button class="c-palette-card" data-theme-id="' + t.id + '" aria-label="' + t.name + '"' +
+          ' style="--card-bg:' + t.bg + ';--card-ac:' + t.accent + '">' +
+          '<span class="c-palette-card__perfs">' + PERFS + '</span>' +
+          '<span class="c-palette-card__body">' +
+            '<span class="c-palette-card__dot"></span>' +
+            '<span class="c-palette-card__name">' + t.name + '</span>' +
+          '</span>' +
+          '<span class="c-palette-card__perfs">' + PERFS + '</span>' +
         '</button>';
     });
 
-    panel.innerHTML =
-      '<div class="c-palette-panel__inner">' +
-        '<div class="c-palette-panel__header">' +
-          '<span class="c-palette-panel__title">换个心情</span>' +
-          '<button class="c-palette-panel__close" id="js-palette-close" aria-label="关闭">✕</button>' +
+    overlay.innerHTML =
+      '<div class="c-palette-modal" role="dialog" aria-label="配色主题 · 换个心情">' +
+        '<div class="c-palette-modal__header">' +
+          '<span class="c-palette-modal__title">换个心情 · Many Faces</span>' +
+          '<button class="c-palette-modal__close" id="js-palette-close" aria-label="关闭">✕</button>' +
         '</div>' +
-        '<section class="c-palette-section">' +
-          '<p class="c-palette-section__label">Many Faces · 角色配色</p>' +
-          '<div class="c-palette-grid" id="js-palette-grid">' + grid + '</div>' +
-        '</section>' +
-        '<section class="c-palette-section">' +
-          '<p class="c-palette-section__label">自定义强调色</p>' +
-          '<div class="c-palette-custom">' +
-            '<input type="range" class="c-palette-hue" id="js-palette-hue" min="0" max="359" value="0" aria-label="色相">' +
-            '<div class="c-palette-custom__preview" id="js-palette-preview"></div>' +
-          '</div>' +
-          '<p class="c-palette-section__hint">仅调整强调色，背景保持中性</p>' +
-        '</section>' +
-        '<button class="c-palette-panel__reset" id="js-palette-reset">还原默认配色</button>' +
+        '<div class="c-palette-modal__body">' +
+          '<div class="c-palette-cards" id="js-palette-grid">' + cards + '</div>' +
+        '</div>' +
+        '<div class="c-palette-modal__footer">' +
+          '<span class="c-palette-footer__label">自定义色</span>' +
+          '<input type="range" class="c-palette-hue" id="js-palette-hue" min="0" max="359" value="0" aria-label="自定义色相">' +
+          '<div class="c-palette-custom__preview" id="js-palette-preview"></div>' +
+          '<button class="c-palette-panel__reset" id="js-palette-reset">还原默认</button>' +
+        '</div>' +
       '</div>';
 
-    document.body.appendChild(panel);
-    return { trigger: trigger, panel: panel };
+    document.body.appendChild(overlay);
+    return { trigger: trigger, overlay: overlay };
   }
 
   function updateHuePreview(hue) {
@@ -262,29 +264,29 @@
     });
   }
 
-  function initEvents(trigger, panel) {
+  function initEvents(trigger, overlay) {
     var open = false;
 
-    function openPanel()  {
+    function openOverlay() {
       open = true;
-      panel.classList.add('is-open');
-      panel.setAttribute('aria-hidden', 'false');
+      overlay.classList.add('is-open');
+      overlay.setAttribute('aria-hidden', 'false');
       trigger.setAttribute('aria-expanded', 'true');
+      document.body.style.overflow = 'hidden';
       updateSwatchStates();
     }
-    function closePanel() {
+    function closeOverlay() {
       open = false;
-      panel.classList.remove('is-open');
-      panel.setAttribute('aria-hidden', 'true');
+      overlay.classList.remove('is-open');
+      overlay.setAttribute('aria-hidden', 'true');
       trigger.setAttribute('aria-expanded', 'false');
+      document.body.style.overflow = '';
     }
 
-    trigger.addEventListener('click', function (e) { e.stopPropagation(); open ? closePanel() : openPanel(); });
-    document.getElementById('js-palette-close').addEventListener('click', closePanel);
-    document.addEventListener('click', function (e) {
-      if (open && !panel.contains(e.target) && e.target !== trigger) closePanel();
-    });
-    document.addEventListener('keydown', function (e) { if (e.key === 'Escape' && open) closePanel(); });
+    trigger.addEventListener('click', function (e) { e.stopPropagation(); open ? closeOverlay() : openOverlay(); });
+    document.getElementById('js-palette-close').addEventListener('click', closeOverlay);
+    overlay.addEventListener('click', function (e) { if (e.target === overlay) closeOverlay(); });
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape' && open) closeOverlay(); });
 
     document.getElementById('js-palette-grid').addEventListener('click', function (e) {
       var btn = e.target.closest('[data-theme-id]');
@@ -328,7 +330,7 @@
     } catch (e) {}
 
     var ui = buildUI();
-    initEvents(ui.trigger, ui.panel);
+    initEvents(ui.trigger, ui.overlay);
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
Replace the small bottom-right sliding panel with a near-full-screen overlay. Each of the 39 character palettes is now rendered as a portrait film-strip card — dark bg, accent-colour dot, full name in EB Garamond italic, perforations top and bottom — matching the au-palette-strip aesthetic. Footer bar holds the custom hue slider + reset button.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQ2KB8THn3pSvEfbAUzeFn)_