### PR TITLE
fix: prevent nav items from wrapping to second line

### DIFF
--- a/_sass/5-components/_header.scss
+++ b/_sass/5-components/_header.scss
@@ -47,7 +47,7 @@
 
 .c-nav__list {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   list-style: none;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
导航栏右侧新增调色板按钮后空间变紧，「Say Hello」被挤到第二行。

**修复**：将 `.c-nav__list` 的 `flex-wrap: wrap` 改为 `flex-wrap: nowrap`，桌面端所有菜单项保持在同一行。手机端（<900px）早已是 nowrap + 横向滚动，逻辑一致。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTNH7PAM5NkfmPv1d2Y6To)_