### PR TITLE
fix: nav text wrapping + dynamic post count by category

### DIFF
--- a/_sass/5-components/_header.scss
+++ b/_sass/5-components/_header.scss
@@ -60,6 +60,7 @@
   font-size: 13px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+  white-space: nowrap;
   color: $ink-soft;
   border-radius: 999px;
   transition: $global-transition;

--- a/_sass/5-components/_header.scss
+++ b/_sass/5-components/_header.scss
@@ -47,7 +47,7 @@
 
 .c-nav__list {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   list-style: none;
   margin: 0;
   padding: 0;

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@ layout: home
 
 <script>
 (function () {
+  window.TOTAL_POSTS = {{ site.posts.size }};
   try {
     var p = new URLSearchParams(window.location.search);
     var active = 'all';
@@ -129,8 +130,8 @@ layout: home
   {% if site.posts.size > 0 %}
 
   <div class="c-section-heading">
-    <h3 class="c-section-heading__title">All Stories</h3>
-    <span class="c-section-heading__meta">{{ site.posts.size }} posts</span>
+    <h3 class="c-section-heading__title" id="js-section-title">All Stories</h3>
+    <span class="c-section-heading__meta" id="js-post-count">总计 {{ site.posts.size }} 篇</span>
   </div>
 
   <div class="c-post-grid">

--- a/js/main.js
+++ b/js/main.js
@@ -80,6 +80,20 @@ $(document).ready(function () {
     $('[data-empty]').toggle(isEmpty);
     var gridVisible = $('.c-post-grid .c-post:not(.is-hidden)').length;
     $('.c-section-heading').toggle(gridVisible > 0);
+
+    var total = window.TOTAL_POSTS || 0;
+    var titleEl = document.getElementById('js-section-title');
+    var countEl = document.getElementById('js-post-count');
+    if (titleEl) {
+      titleEl.textContent = filter === 'all' ? 'All Stories' : filter;
+    }
+    if (countEl) {
+      if (filter === 'all') {
+        countEl.textContent = '总计 ' + total + ' 篇';
+      } else {
+        countEl.textContent = '当前 ' + visible + ' · 总计 ' + total;
+      }
+    }
   }
 
   function showGallery() {


### PR DESCRIPTION
两个修复：

**1. Nav 按钮文字折行**
桌面端 `.c-nav__item` 缺少 `white-space: nowrap`，导致「AU STORY」「SAY HELLO」在按钮内部换行变成两行。补上后，所有菜单项文字保持单行。

**2. 帖子数显示：总计 + 当前分类**
原来的「100 posts」是 Jekyll 静态渲染的总数，切换分类后不会更新。现在：
- 默认（All）：「总计 100 篇」
- 切换分类后：「当前 N · 总计 100」，同时标题也更新为对应分类名

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTNH7PAM5NkfmPv1d2Y6To)_