### PR TITLE
fix: use English for post count display

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@ layout: home
 
   <div class="c-section-heading">
     <h3 class="c-section-heading__title" id="js-section-title">All Stories</h3>
-    <span class="c-section-heading__meta" id="js-post-count">总计 {{ site.posts.size }} 篇</span>
+    <span class="c-section-heading__meta" id="js-post-count">{{ site.posts.size }} posts</span>
   </div>
 
   <div class="c-post-grid">

--- a/js/main.js
+++ b/js/main.js
@@ -89,9 +89,9 @@ $(document).ready(function () {
     }
     if (countEl) {
       if (filter === 'all') {
-        countEl.textContent = '总计 ' + total + ' 篇';
+        countEl.textContent = total + ' posts';
       } else {
-        countEl.textContent = '当前 ' + visible + ' · 总计 ' + total;
+        countEl.textContent = visible + ' showing · ' + total + ' total';
       }
     }
   }


### PR DESCRIPTION
将帖子数量改回英文：默认显示 `100 posts`，分类筛选后显示 `N showing · 100 total`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTNH7PAM5NkfmPv1d2Y6To)_