### PR TITLE
拍立得卡组升级 + 寄信修复（Web3Forms）

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,9 @@ author-name:    Winter Sun
 author-image:   heading-normal.jpg
 author-job:     Translator / Romantic / Dreamer
 author-email:   winterzhangyixuan@qq.com # Add your email for contant form.
+# 寄信用的 Web3Forms access key —— 去 https://web3forms.com 输入上面的邮箱免费领取，
+# 把领到的那串 key 填进下面这双引号里即可（联系页表单 + 信卡寄信都读它）。留空则寄信功能停用。
+web3forms-key:  ""
 author-weibo:   https://weibo.com/wintersunzhang
 author-bilibili:   https://space.bilibili.com/185894171
 author-redbook: https://www.xiaohongshu.com/user/profile/5cb52bc3000000001200caab?xsec_token=YBDAjPaqx6wqyz2-Im0YSlwFtPkWgBp8nkMX0rfyntfEo=&xsec_source=app_share&xhsshare=CopyLink&shareRedId=N0lENTVHRzw2NzUyOTgwNjc1OTdHRkdL&apptime=1777654818&share_id=fcdbd7106d0a46cba87e52375304c1d5

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ author-job:     Translator / Romantic / Dreamer
 author-email:   winterzhangyixuan@qq.com # Add your email for contant form.
 # 寄信用的 Web3Forms access key —— 去 https://web3forms.com 输入上面的邮箱免费领取，
 # 把领到的那串 key 填进下面这双引号里即可（联系页表单 + 信卡寄信都读它）。留空则寄信功能停用。
-web3forms-key:  ""
+web3forms-key:  "8dfcdf24-bd70-4642-b24e-2574a0e6f4a0"
 author-weibo:   https://weibo.com/wintersunzhang
 author-bilibili:   https://space.bilibili.com/185894171
 author-redbook: https://www.xiaohongshu.com/user/profile/5cb52bc3000000001200caab?xsec_token=YBDAjPaqx6wqyz2-Im0YSlwFtPkWgBp8nkMX0rfyntfEo=&xsec_source=app_share&xhsshare=CopyLink&shareRedId=N0lENTVHRzw2NzUyOTgwNjc1OTdHRkdL&apptime=1777654818&share_id=fcdbd7106d0a46cba87e52375304c1d5

--- a/_includes/form.html
+++ b/_includes/form.html
@@ -1,5 +1,7 @@
 <div class="c-form-box">
-  <form class="c-form" action="{% if site.author-email %}https://formspree.io/{{site.author-email}}{% else %}#{% endif %}" method="POST">
+  <form class="c-form" action="{% if site.web3forms-key and site.web3forms-key != "" %}https://api.web3forms.com/submit{% else %}#{% endif %}" method="POST">
+    <input type="hidden" name="access_key" value="{{site.web3forms-key}}">
+    <input type="hidden" name="redirect" value="{{ site.url }}{{ site.baseurl }}/contact/thanks/">
     <div class="c-form-bnt__close" data-icon='ei-close' data-size='s'></div>
       <div class="c-form__title">You can contact me!</div>
     <div class="c-form__group">
@@ -8,15 +10,15 @@
     </div>
     <div class="c-form__group">
       <label for="form-email">Your Email (Required)</label>
-      <input class="c-form__input" id="form-email" type="email" name="_replyto" required>
+      <input class="c-form__input" id="form-email" type="email" name="email" required>
     </div>
     <div class="c-form__group">
       <label for="form-subject">Subject</label>
-      <input class="c-form__input" id="form-subject" type="text" name="_subject">
+      <input class="c-form__input" id="form-subject" type="text" name="subject">
     </div>
     <div class="c-form__group">
       <label for="form-text">Your Message (Required)</label>
-      <textarea class="c-form__input" id="form-text" name="text" rows="10" required></textarea>
+      <textarea class="c-form__input" id="form-text" name="message" rows="10" required></textarea>
     </div>
     <div class="c-form__group">
       <button class="c-btn c-btn--secondary c-btn--big c-btn--shadow" type="submit">Send</button>

--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -1,4 +1,4 @@
-<script>window.SITE_BASEURL = "{{site.baseurl}}";{% if site.author-email %} window.HELLO_ENDPOINT = "https://formspree.io/{{site.author-email}}";{% endif %}</script>
+<script>window.SITE_BASEURL = "{{site.baseurl}}";{% if site.web3forms-key and site.web3forms-key != "" %} window.HELLO_ENDPOINT = "https://api.web3forms.com/submit"; window.WEB3FORMS_KEY = "{{site.web3forms-key}}";{% endif %}</script>
 {% assign cache_bust = site.time | date: '%Y%m%d%H%M' %}
 <script src="{{site.baseurl}}/js/jquery-3.3.1.min.js"></script>
 <script src="{{site.baseurl}}/js/evil-icons.min.js"></script>

--- a/_pages/contact/index.html
+++ b/_pages/contact/index.html
@@ -66,8 +66,9 @@ permalink: /contact/
     {% endif %}
   </ul>
 
-  {% if site.author-email %}
-  <form id="hello-form" class="c-hello__form" action="https://formspree.io/{{site.author-email}}" method="POST">
+  {% if site.web3forms-key and site.web3forms-key != "" %}
+  <form id="hello-form" class="c-hello__form" action="https://api.web3forms.com/submit" method="POST">
+    <input type="hidden" name="access_key" value="{{site.web3forms-key}}">
     <div class="c-section-heading">
       <h3 class="c-section-heading__title">A Letter</h3>
       <span class="c-section-heading__meta">straight to my inbox</span>
@@ -80,20 +81,20 @@ permalink: /contact/
       </label>
       <label class="c-hello__field">
         <span class="c-hello__label">Your email</span>
-        <input class="c-hello__input" type="email" name="_replyto" required>
+        <input class="c-hello__input" type="email" name="email" required>
       </label>
     </div>
     <label class="c-hello__field">
       <span class="c-hello__label">Subject</span>
-      <input class="c-hello__input" type="text" name="_subject">
+      <input class="c-hello__input" type="text" name="subject">
     </label>
     <label class="c-hello__field">
       <span class="c-hello__label">Your letter</span>
-      <textarea class="c-hello__input c-hello__input--area" name="text" rows="8" required></textarea>
+      <textarea class="c-hello__input c-hello__input--area" name="message" rows="8" required></textarea>
     </label>
 
     <button class="c-hello__submit" type="submit">Send the letter</button>
-    <input type="hidden" name="_next" value="{{ site.baseurl }}/contact/thanks/">
+    <input type="hidden" name="redirect" value="{{ site.url }}{{ site.baseurl }}/contact/thanks/">
   </form>
   {% endif %}
 </section>

--- a/_sass/5-components/_polaroid-notes.scss
+++ b/_sass/5-components/_polaroid-notes.scss
@@ -31,7 +31,7 @@
 
 /* —— 照片背面编辑器（拍立得背面：上半黑条 + 下方书写区，翻入动画）—— */
 .pol-editor {
-  width: min(380px, 92vw);
+  width: min(440px, 92vw);
   background: #f6f1e7;            /* 相纸 */
   border-radius: 4px;
   padding: 9px;                  /* 相纸白边 */
@@ -172,10 +172,13 @@
 .pol-deck {
   position: fixed; left: 20px; bottom: 72px; z-index: 1098;  /* 低于浮标，藏在它后面 */
   display: none;                 /* 解锁后由 JS 置为 block */
-  width: 152px; height: 150px;
+  --cardw: 172px;                /* 缩略卡宽度 */
+  --step: 126px;                 /* 展开时每张的竖向错落步长（≈卡高） */
+  --peek: 24px;                  /* 收起时整叠露出的高度 */
+  width: var(--cardw); height: 168px;
 }
 .pol-card {
-  position: absolute; left: 0; bottom: 0; width: 152px;
+  position: absolute; left: 0; bottom: 0; width: var(--cardw);
   display: flex; flex-direction: column; align-items: stretch;
   padding: 8px 8px 0; background: #fbf9f3; border: none; border-radius: 3px;
   box-shadow: 0 10px 26px rgba(0, 0, 0, 0.4); cursor: pointer;
@@ -183,18 +186,18 @@
   transition: transform 0.45s cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 0.25s ease;
 }
 /* 触屏（无 hover）：直接错落展开成一叠，每张都点得到 */
-.pol-card { transform: translateY(calc(var(--i) * -112px)) rotate(-3deg); }
+.pol-card { transform: translateY(calc(var(--i) * var(--step) * -1)) rotate(-3deg); }
 /* 有鼠标：平时整叠缩在浮标后只露一条；悬停浮标或卡组时，像抽屉一样展开 */
 @media (hover: hover) {
-  .pol-card { transform: translateY(calc(100% - 22px - var(--i) * 7px)) rotate(calc(var(--i) * 3deg - 2deg)); }
+  .pol-card { transform: translateY(calc(100% - var(--peek) - var(--i) * 7px)) rotate(calc(var(--i) * 3deg - 2deg)); }
   .pol-deck:hover .pol-card,
-  .pol-lock:hover ~ .pol-deck .pol-card { transform: translateY(calc(var(--i) * -112px)) rotate(-3deg); box-shadow: 0 18px 38px rgba(0, 0, 0, 0.5); }
+  .pol-lock:hover ~ .pol-deck .pol-card { transform: translateY(calc(var(--i) * var(--step) * -1)) rotate(-3deg); box-shadow: 0 18px 38px rgba(0, 0, 0, 0.5); }
   .pol-deck:hover .pol-card:hover,
-  .pol-lock:hover ~ .pol-deck .pol-card:hover { transform: translateY(calc(var(--i) * -112px)) rotate(0deg) scale(1.03); box-shadow: 0 22px 44px rgba(0, 0, 0, 0.55); }
+  .pol-lock:hover ~ .pol-deck .pol-card:hover { transform: translateY(calc(var(--i) * var(--step) * -1)) rotate(0deg) scale(1.03); box-shadow: 0 22px 44px rgba(0, 0, 0, 0.55); }
 }
 .pol-card-photo {
   display: flex; align-items: center; justify-content: center;
-  height: 82px; border-radius: 2px;
+  height: 96px; border-radius: 2px;
 }
 .pol-card-star { font-size: 23px; color: rgba(255, 255, 255, 0.82); text-shadow: 0 1px 4px rgba(0, 0, 0, 0.3); }
 /* 歌词分层排版：引子(轻) → 主角(衬线斜体放大) → 署名(极小) → 日期 */
@@ -204,14 +207,13 @@
 .pol-card-credit { font-family: 'EB Garamond', serif; font-style: italic; font-size: 8.5px; letter-spacing: 0.7px; color: #c0b29a; margin-top: 4px; }
 .pol-card-cap i { font-family: 'EB Garamond', serif; font-style: italic; font-size: 10px; color: #9a8f7c; margin-top: 2px; }
 @media (max-width: 480px) {
-  .pol-deck { width: 138px; bottom: 76px; }
-  .pol-card { width: 138px; }
-  .pol-card-photo { height: 74px; }
+  .pol-deck { --cardw: 150px; --step: 120px; height: 150px; bottom: 76px; }
+  .pol-card-photo { height: 84px; }
 }
 
 /* 翻开的编辑卡（沿用相纸 + 黑条的语言）*/
 .pol-lucky-card {
-  width: min(380px, 92vw);
+  width: min(440px, 92vw);
   background: #f6f1e7; border-radius: 5px; padding: 9px;
   box-shadow: 0 30px 70px rgba(0, 0, 0, 0.6);
   transform: translateY(14px) scale(0.96); opacity: 0;
@@ -225,6 +227,16 @@
 .pol-lucky-date { font-family: 'EB Garamond', serif; font-style: italic; font-size: 15px; letter-spacing: 0.3px; color: #e7dcc6; }
 .pol-lucky-nav { border: none; background: transparent; color: rgba(231, 220, 198, 0.55); font-size: 21px; line-height: 1; cursor: pointer; padding: 0 8px; }
 .pol-lucky-nav:hover { color: #fff; }
+/* 主题色色卡（与画册同源）：一排小圆点，选中的描一圈 */
+.pol-theme { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; padding: 11px 14px 1px; }
+.pol-sw {
+  width: 18px; height: 18px; border-radius: 50%; padding: 0; cursor: pointer;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.pol-sw:hover { transform: scale(1.16); }
+.pol-sw.on { box-shadow: 0 0 0 2px #f6f1e7, 0 0 0 3.5px var(--c-accent, #b08968); }
 .pol-lucky-body { padding: 14px 14px 2px; }
 .pol-lucky-row { display: flex; align-items: flex-start; gap: 11px; margin-bottom: 11px; cursor: text; }
 .pol-lucky-no { flex: none; width: 22px; text-align: center; font-family: 'Ma Shan Zheng', cursive; font-size: 21px; color: #b08968; line-height: 1.35; }

--- a/js/polaroid-notes.js
+++ b/js/polaroid-notes.js
@@ -39,10 +39,22 @@
     {
       id: "toself", kind: "letter", ls: "wiw-toself",
       grad: "linear-gradient(145deg, #8a7459 0%, #5b4a52 52%, #34303a 100%)",
-      q1: "Dear me —", q2: "a letter to myself", credit: "to be read on a later day",
+      q1: "And I'll", q2: "meet you there someday", credit: "Augustana · Meet You There",
       hint: "存着慢慢写；封缄后，它会寄进你的邮箱。",
       subjectDefault: "「致自己」"
     }
+  ];
+  // 主题色：与「Many Faces of Sam」画册 / _data/au_palettes.yml 同源的强调色。
+  // 写卡片时可点选，换这张卡的强调色 + 角落缩略卡的相纸渐变；选择记在本地。
+  // key 空字符串 = 该卡自带的「原色」，由 JOURNALS[i].grad 决定。
+  var THEMES = [
+    { key: "ice",     cn: "冰蓝眼眸",   en: "Ice-Blue Eyes",   accent: "#5f96c2", grad: "linear-gradient(145deg, #7fb0d8 0%, #4a6680 55%, #1e1a16 100%)" },
+    { key: "sapphire",cn: "电光钴蓝",   en: "Spotlight Sapphire", accent: "#4a87ee", grad: "linear-gradient(145deg, #5a93f0 0%, #34527e 52%, #13151c 100%)" },
+    { key: "sawdust", cn: "锯末粗木",   en: "Sawdust Timber",  accent: "#b0803e", grad: "linear-gradient(145deg, #c79456 0%, #6f5436 55%, #1b1510 100%)" },
+    { key: "mane",    cn: "总统鬃金",   en: "President's Mane", accent: "#d4a82a", grad: "linear-gradient(145deg, #e0bd4a 0%, #7d6320 52%, #0b0a12 100%)" },
+    { key: "crimson", cn: "红镜红",     en: "Crimson Lens",    accent: "#d94040", grad: "linear-gradient(145deg, #e25a5a 0%, #7d3530 55%, #1b1310 100%)" },
+    { key: "lunar",   cn: "月球蔚蓝",   en: "Lunar Blue",      accent: "#7eb0d5", grad: "linear-gradient(145deg, #8fbce0 0%, #44607e 52%, #162038 100%)" },
+    { key: "mist",    cn: "孤枪冷雾蓝", en: "Lone Mist",       accent: "#8fa0b0", grad: "linear-gradient(145deg, #a3b3c2 0%, #54616e 52%, #14181f 100%)" }
   ];
   // 钢笔笔尖（SVG，缺口与气孔留成镂空，像真的笔尖）：
   var PEN_SVG = '<svg class="pol-lock-pen" viewBox="0 0 24 24" width="19" height="19" aria-hidden="true">' +
@@ -101,6 +113,19 @@
     stores[j.id] = s; return s;
   }
   function journalById(id) { for (var i = 0; i < JOURNALS.length; i++) if (JOURNALS[i].id === id) return JOURNALS[i]; return null; }
+
+  /* ========== 主题色：每张卡选一个，记在本地 ========== */
+  var LS_THEME = "wiw-pol-themes";
+  function themeMap() { try { return JSON.parse(localStorage.getItem(LS_THEME)) || {}; } catch (e) { return {}; } }
+  function themeKeyOf(jid) { return themeMap()[jid] || ""; }
+  function setThemeKey(jid, key) {
+    var m = themeMap(); if (key) m[jid] = key; else delete m[jid];
+    try { localStorage.setItem(LS_THEME, JSON.stringify(m)); } catch (e) {}
+  }
+  function themeByKey(key) { for (var i = 0; i < THEMES.length; i++) if (THEMES[i].key === key) return THEMES[i]; return null; }
+  function gradOf(j) { var t = themeByKey(themeKeyOf(j.id)); return t ? t.grad : j.grad; }
+  function accentOf(j) { var t = themeByKey(themeKeyOf(j.id)); return t ? t.accent : (j.accent || ""); }
+  var deckPhotos = {};   // jid → 角落缩略卡里那块「照片」元素，供换主题时即时改色
 
   var devMode = (PASS_HASH === "PUT_YOUR_HASH_HERE");
   function passHash() { return devMode ? localStorage.getItem(LS_PASS_DEV) : PASS_HASH; }
@@ -369,7 +394,8 @@
         pin.innerHTML =
           '<span class="pol-card-photo"><span class="pol-card-star">✦</span></span>' +
           '<span class="pol-card-cap"><span class="pol-card-q1"></span><span class="pol-card-q2"></span><span class="pol-card-credit"></span><i></i></span>';
-        pin.querySelector(".pol-card-photo").style.background = j.grad;
+        var photo = pin.querySelector(".pol-card-photo");
+        photo.style.background = gradOf(j); deckPhotos[j.id] = photo;
         pin.querySelector(".pol-card-q1").textContent = j.q1;
         pin.querySelector(".pol-card-q2").textContent = j.q2;
         pin.querySelector(".pol-card-credit").textContent = j.credit;
@@ -387,7 +413,7 @@
   }
 
   /* —— 共用的翻开编辑卡（按当前 journal 的 kind 重建内页）—— */
-  var jBack, jDateEl, jSavedEl, jHintEl, jBodyEl, jSendMsgEl, curJournal = null, curDay = null, jInputs = [], jSaveTimer = null;
+  var jBack, jCardEl, jThemeEl, jDateEl, jSavedEl, jHintEl, jBodyEl, jSendMsgEl, curJournal = null, curDay = null, jInputs = [], jSaveTimer = null;
   var letterSubj, letterRead, letterBody; // 信卡专用：标题 / 待重读日 / 正文
   function autoGrow(t) { t.style.height = "auto"; t.style.height = Math.max(30, t.scrollHeight) + "px"; }
   function flashSaved() { if (jSavedEl) { jSavedEl.classList.add("show"); setTimeout(function () { jSavedEl.classList.remove("show"); }, 1200); } }
@@ -401,6 +427,7 @@
           '<span class="pol-lucky-date"></span>' +
           '<button class="pol-lucky-nav" type="button" data-d="1" aria-label="后一天">›</button>' +
         '</div>' +
+        '<div class="pol-theme" aria-label="主题色"></div>' +
         '<div class="pol-lucky-body"></div>' +
         '<div class="pol-lucky-foot"><span class="pol-lucky-hint"></span>' +
           '<span class="pol-lucky-foot-r"><span class="pol-lucky-sendmsg"></span><span class="pol-saved pol-lucky-saved">已收好 ✓</span>' +
@@ -408,6 +435,8 @@
           '<button class="pol-lucky-x" type="button">收起</button></span></div>' +
       '</div>';
     document.body.appendChild(jBack);
+    jCardEl = jBack.querySelector(".pol-lucky-card");
+    jThemeEl = jBack.querySelector(".pol-theme");
     jDateEl = jBack.querySelector(".pol-lucky-date");
     jSavedEl = jBack.querySelector(".pol-lucky-saved");
     jHintEl = jBack.querySelector(".pol-lucky-hint");
@@ -455,6 +484,26 @@
       jBodyEl.appendChild(free); jInputs.push(free);
     }
   }
+  function applyTheme(j) {
+    var ac = accentOf(j);
+    if (jCardEl) { if (ac) jCardEl.style.setProperty("--c-accent", ac); else jCardEl.style.removeProperty("--c-accent"); }
+    var ph = deckPhotos[j.id]; if (ph) ph.style.background = gradOf(j);
+  }
+  function renderThemeBar(j) {
+    if (!jThemeEl) return;
+    jThemeEl.innerHTML = "";
+    var cur = themeKeyOf(j.id);
+    var opts = [{ key: "", grad: j.grad, cn: "原色", en: "Original" }].concat(THEMES);
+    for (var i = 0; i < opts.length; i++) {
+      (function (o) {
+        var b = document.createElement("button");
+        b.type = "button"; b.className = "pol-sw" + (o.key === cur ? " on" : "");
+        b.style.background = o.grad; b.title = o.cn + " · " + o.en;
+        b.addEventListener("click", function () { setThemeKey(j.id, o.key); applyTheme(j); renderThemeBar(j); });
+        jThemeEl.appendChild(b);
+      })(opts[i]);
+    }
+  }
   function loadDay(day) {
     curDay = day;
     var rec = storeOf(curJournal).get(day) || {};
@@ -474,6 +523,8 @@
     jBack.setAttribute("data-kind", j.kind);
     jHintEl.textContent = j.hint || "";
     buildBodyFor(j);
+    renderThemeBar(j);
+    applyTheme(j);
     jBack.classList.add("open");
     if (jSendMsgEl) jSendMsgEl.classList.remove("show");
     if (j.kind === "letter") {

--- a/js/polaroid-notes.js
+++ b/js/polaroid-notes.js
@@ -9,7 +9,8 @@
   /* ========== 你的配置 ========== */
   // ↓↓↓ 用文末小工具把你的密码转成哈希，替换下面这行的占位符：
   var PASS_HASH = "2432187070";
-  var HELLO_ENDPOINT = (typeof window !== "undefined" && window.HELLO_ENDPOINT) || ""; // 寄信给自己用的 Formspree 地址
+  var HELLO_ENDPOINT = (typeof window !== "undefined" && window.HELLO_ENDPOINT) || ""; // 寄信端点（Web3Forms）
+  var WEB3FORMS_KEY = (typeof window !== "undefined" && window.WEB3FORMS_KEY) || "";   // Web3Forms 免费 access key
   var NOTE_FONT = "'Caveat','Ma Shan Zheng',cursive";
   var FONT_LINK = "https://fonts.googleapis.com/css2?family=Caveat:wght@500;600&family=Ma+Shan+Zheng&display=swap";
   var LONGPRESS_MS = 480;
@@ -595,15 +596,17 @@
     if (!curJournal || curJournal.kind !== "letter") return;
     var body = (letterBody.value || "").trim();
     if (!body) { setSendMsg("信还是空的呢…"); return; }
-    if (!HELLO_ENDPOINT) { setSendMsg("没找到寄信地址 :("); return; }
+    if (!HELLO_ENDPOINT || !WEB3FORMS_KEY) { setSendMsg("还没配好寄信钥匙 :("); return; }
     setSendMsg("封缄寄送中…");
     var fd = new FormData();
-    fd.append("name", "To Myself");
-    fd.append("_subject", composeSubject());
-    fd.append("text", body + (letterRead.value ? "\n\n— 待 " + niceDate(letterRead.value) + " 再读 —" : ""));
+    fd.append("access_key", WEB3FORMS_KEY);
+    fd.append("from_name", "To Myself");
+    fd.append("subject", composeSubject());
+    fd.append("message", body + (letterRead.value ? "\n\n— 待 " + niceDate(letterRead.value) + " 再读 —" : ""));
     fetch(HELLO_ENDPOINT, { method: "POST", headers: { "Accept": "application/json" }, body: fd })
-      .then(function (res) {
-        if (res.ok) {
+      .then(function (res) { return res.json().catch(function () { return { success: res.ok }; }); })
+      .then(function (data) {
+        if (data && data.success) {
           setSendMsg("已寄出 ✓ 去你的邮箱等它");
           try { localStorage.removeItem(curJournal.ls); } catch (e) {}
           letterSubj.value = curJournal.subjectDefault || ""; letterRead.value = ""; letterBody.value = ""; autoGrow(letterBody);


### PR DESCRIPTION
角落拍立得卡组的几处升级，外加把失效的寄信功能修好。

## 改了什么

**1. 信卡歌词换成 Augustana《Meet You There》**
「致自己」那张相纸下沿改成分层歌词：*And I'll* → **meet you there someday** → *Augustana · Meet You There*，呼应「写给未来的自己」的设定。

**2. 拍立得做大 + 主题色卡**
- 打开写字的卡桌面上限 380→440px（手机仍 `92vw` 兜底，不溢出）。
- 角落缩略卡用 CSS 变量参数化尺寸，桌面 152→172px、手机 138→150px，竖向堆叠步长同步调大。
- 每张卡加一排「画册同源」主题色卡（取自 `_data/au_palettes.yml`），点选即换强调色 + 缩略卡相纸渐变，记在本地，含「原色」重置。

**3. 寄信从失效的 Formspree 切到 Web3Forms**
旧的 `formspree.io/<邮箱>` 老格式早已停用，导致联系页表单、弹窗表单、信卡「封缄寄出」全部石沉大海。现统一改用 Web3Forms：
- `_config.yml` 新增 `web3forms-key`，已填入 access key。
- key 留空时模板不输出寄信地址，安全降级，不会假装能发。
- 信卡按 Web3Forms 返回的 JSON `success` 判断成败。

## 部署后验证
- 联系页填一封发给自己 → 应跳 thanks 页 → QQ 邮箱收到。
- 信卡：解锁 → 卡组第三张「致自己」→ 写两句 → 封缄寄出。
- ⚠️ 第一封可能进垃圾箱（QQ 邮箱爱拦生面孔），标记非垃圾后即稳。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrrrRybmfHTqJFMfbEmqJB)_