### PR TITLE
深色模式：修复宝丽来卡片与背景糊在一起

### DIFF
--- a/_includes/au-palette-style.html
+++ b/_includes/au-palette-style.html
@@ -34,8 +34,8 @@
   /* —— 深色模式：该系列深底 —— */
   :root[data-theme="dark"]{
     --c-bg:          {{ p.bg }};
-    --c-bg-soft:     {{ p.bg }};
-    --c-paper:       {{ p.bg }};
+    --c-bg-soft:     color-mix(in srgb, {{ p.bg }}, #ffffff 6%);
+    --c-paper:       color-mix(in srgb, {{ p.bg }}, #ffffff 9%);
     --c-ink:         {{ p.text }};
     --c-ink-soft:    {{ p.text }};
     --c-muted:       {{ p.muted }};
@@ -53,7 +53,9 @@
   }
   @media (prefers-color-scheme: dark){
     :root:not([data-theme="light"]){
-      --c-bg: {{ p.bg }}; --c-bg-soft: {{ p.bg }}; --c-paper: {{ p.bg }};
+      --c-bg: {{ p.bg }};
+      --c-bg-soft: color-mix(in srgb, {{ p.bg }}, #ffffff 6%);
+      --c-paper: color-mix(in srgb, {{ p.bg }}, #ffffff 9%);
       --c-ink: {{ p.text }}; --c-ink-soft: {{ p.text }};
       --c-muted: {{ p.muted }}; --c-muted-soft: {{ p.muted }};
       --c-line: rgba(255,255,255,.10); --c-line-strong: rgba(255,255,255,.20);

--- a/_sass/5-components/_polaroid.scss
+++ b/_sass/5-components/_polaroid.scss
@@ -8,6 +8,7 @@
 
 .c-post {
   background: var(--c-paper);
+  border: 1px solid var(--c-line);
   border-radius: 3px;
   padding: 9px 9px 0;
   box-shadow:


### PR DESCRIPTION
在带系列/心情配色的深色页面上，文章的宝丽来卡片几乎看不出是卡片——因为卡片纸面（`--c-paper`）被设成了和整页背景（`--c-bg`）同一个颜色，而卡片唯一的立体感来源（纯黑投影）打在近黑背景上等于没有。

本次改动：

- **`au-palette-style.html`**：深色模式下让卡片纸面比背景亮一档（+9% 白）、次级表面亮 +6%，和全站默认深色主题一样让卡片"浮"起来。
- **`_polaroid.scss`**：给卡片补一道 1px 细边（用现成的描边色令牌），即使色差很小也能看出卡片轮廓。

浅色模式不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5VZHirwf6piYhg4HSQumf

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5VZHirwf6piYhg4HSQumf)_