### PR TITLE
藏品架：碟片 NAS 导入状态 + 馆长点角色格子优先添藏品

### DIFF
--- a/sam/shelf/index.html
+++ b/sam/shelf/index.html
@@ -267,6 +267,25 @@
     width: 100%; max-width: 860px; margin: 10px 0 0;
     font-weight: 300; font-size: 11.5px; line-height: 2; color: #8a7558; text-align: center;
   }
+  body.is-curator .map-hint__viewer { display: none; }
+  body:not(.is-curator) .map-hint__curator { display: none; }
+
+  /* 角色小菜单（馆长点画册地图格子时弹出） */
+  .sheet--mini { width: min(360px, 100%); }
+  .cm-btns { display: flex; flex-direction: column; gap: 9px; }
+  .cm-btn {
+    padding: 12px; border-radius: 999px; cursor: pointer;
+    border: 1px solid rgba(255,222,180,.2); background: #0f0b07;
+    color: #cbb891; font-size: 13.5px; letter-spacing: 1px;
+  }
+  .cm-btn:hover { border-color: rgba(255,222,180,.45); color: #ece1d0; }
+  .cm-btn--main {
+    border-color: rgba(230,190,110,.6);
+    background: linear-gradient(160deg, rgba(203,161,76,.28), rgba(203,161,76,.08));
+    color: #f2e7d2;
+  }
+  .cm-btn--cancel { border: 0; background: none; color: #8a7558; }
+  .cm-btn--cancel:hover { color: #ece1d0; }
 
   .note {
     margin-top: 34px; max-width: 560px; text-align: center;
@@ -469,7 +488,7 @@
   <h2>🎞️ 角色联动 · 画册地图</h2><span class="rule"></span><span class="count" id="map-count"></span>
 </div>
 <div class="map-grid" id="map-grid"></div>
-<p class="map-hint" id="map-hint" style="display:none">收了谁的东西，谁的格子就亮起来。<br>点亮着的格子＝只看他的藏品；点暗着的格子＝去画册看看这张脸。</p>
+<p class="map-hint" id="map-hint" style="display:none">收了谁的东西，谁的格子就亮起来。<br><span class="map-hint__viewer">点亮着的格子＝只看他的藏品；点暗着的格子＝去画册看看这张脸。</span><span class="map-hint__curator">点任何格子＝直接给这个角色添一件藏品（也能筛选、去画册）。</span></p>
 
 <p class="note" id="foot-note">
   这一整架，都是 Winter 一件一件收来的——谁来都可以看，<br>
@@ -505,6 +524,19 @@
 
 <div class="toast" id="toast"></div>
 
+<!-- 角色小菜单（馆长点地图格子时弹出） -->
+<div class="overlay" id="cm-overlay">
+  <div class="sheet sheet--mini" role="dialog" aria-modal="true" aria-label="角色选项">
+    <h2 id="cm-title"></h2>
+    <div class="cm-btns">
+      <button type="button" class="cm-btn cm-btn--main" id="cm-add">＋ 给他添一件藏品</button>
+      <button type="button" class="cm-btn" id="cm-filter">🗄️ 只看他的藏品</button>
+      <button type="button" class="cm-btn" id="cm-gallery">🎞️ 去画册看看他 ↗</button>
+      <button type="button" class="cm-btn cm-btn--cancel" id="cm-cancel">算了，没事</button>
+    </div>
+  </div>
+</div>
+
 <!-- 添加 / 编辑弹窗 -->
 <div class="overlay" id="overlay">
   <div class="sheet" role="dialog" aria-modal="true" aria-label="添加或编辑藏品">
@@ -529,6 +561,7 @@
     <textarea class="f-area" id="f-note" maxlength="300"></textarea>
 
     <div class="toggles">
+      <label class="tog" id="f-nas-row" style="display:none"><input type="checkbox" id="f-nas"><span>📡 已经导进 NAS（Infuse 里能看了）</span></label>
       <label class="tog"><input type="checkbox" id="f-signed"><span>✍️ 上面有他的亲笔签名</span></label>
       <label class="tog"><input type="checkbox" id="f-wish"><span>🌠 还没入手，先放进心愿单</span></label>
     </div>
@@ -558,7 +591,11 @@
   ];
   var FILTERS = [{ id: "all", label: "全部" }]
     .concat(TYPES.map(function (t) { return { id: t.id, label: t.emoji + " " + t.label }; }))
-    .concat([{ id: "signed", label: "✍️ 有签名" }]);
+    .concat([
+      { id: "signed", label: "✍️ 有签名" },
+      { id: "nas", label: "📡 已进 NAS" },
+      { id: "nonas", label: "🎞️ 还没进 NAS" }
+    ]);
 
   var typeById = {};
   TYPES.forEach(function (t) { typeById[t.id] = t; });
@@ -646,6 +683,8 @@
     if (charFilter && it.charId !== charFilter) return false;
     if (filter === "all") return true;
     if (filter === "signed") return !!it.signed;
+    if (filter === "nas") return it.type === "disc" && !!it.nas;
+    if (filter === "nonas") return it.type === "disc" && !it.nas;
     return it.type === filter;
   }
 
@@ -665,7 +704,10 @@
     var em = document.createElement("span"); em.className = "item__emoji"; em.textContent = t.emoji;
     var ty = document.createElement("span"); ty.className = "item__type"; ty.textContent = t.label;
     var bd = document.createElement("span"); bd.className = "item__badges";
-    if (it.signed) bd.textContent = "✍️";
+    var badges = [];
+    if (it.type === "disc" && it.nas) badges.push("📡");
+    if (it.signed) badges.push("✍️");
+    bd.textContent = badges.join(" ");
     top.appendChild(em); top.appendChild(ty); top.appendChild(bd);
     el.appendChild(top);
 
@@ -728,11 +770,15 @@
     allOwn.forEach(function (it) { if (it.charId) coveredIds[it.charId] = (coveredIds[it.charId] || 0) + 1; });
     var covered = Object.keys(coveredIds).length;
 
+    var discs = allOwn.filter(function (it) { return it.type === "disc"; });
+    var nasDone = discs.filter(function (it) { return it.nas; });
+
     var stats = $("stats");
     stats.innerHTML = "";
     [["已入手", allOwn.length + " 件"],
      ["有签名", signed.length + " 件"],
      ["心愿单", allWish.length + " 件"]]
+      .concat(discs.length ? [["碟片进 NAS", nasDone.length + " / " + discs.length]] : [])
       .concat(chars.length ? [["点亮角色", covered + " / " + chars.length]] : [])
       .forEach(function (p) {
         var s = document.createElement("span");
@@ -760,7 +806,9 @@
           d.appendChild(b);
         }
         function go() {
-          if (n) { setCharFilter(c.id); }
+          /* 馆长点格子：优先「给这个角色添藏品」；访客保持原逻辑 */
+          if (isCurator()) { openCharMenu(c, n); }
+          else if (n) { setCharFilter(c.id); }
           else { location.href = "../many-faces/#" + encodeURIComponent(c.mfAnchor); }
         }
         d.addEventListener("click", go);
@@ -802,6 +850,29 @@
     render();
   }
   $("charbar-x").addEventListener("click", function () { setCharFilter(""); });
+
+  /* ————— 角色小菜单（馆长专属） ————— */
+  var cmChar = null;
+  function closeCharMenu() { $("cm-overlay").classList.remove("is-on"); }
+  function openCharMenu(c, n) {
+    cmChar = c;
+    $("cm-title").textContent = c.name + " · " + (c.filmCN || c.film);
+    $("cm-filter").style.display = n ? "block" : "none";
+    $("cm-overlay").classList.add("is-on");
+  }
+  $("cm-add").addEventListener("click", function () {
+    closeCharMenu();
+    if (cmChar) openSheet(null, cmChar.id);
+  });
+  $("cm-filter").addEventListener("click", function () {
+    closeCharMenu();
+    if (cmChar) setCharFilter(cmChar.id);
+  });
+  $("cm-gallery").addEventListener("click", function () {
+    if (cmChar) location.href = "../many-faces/#" + encodeURIComponent(cmChar.mfAnchor);
+  });
+  $("cm-cancel").addEventListener("click", closeCharMenu);
+  $("cm-overlay").addEventListener("click", function (e) { if (e.target === $("cm-overlay")) closeCharMenu(); });
 
   /* ————— 发布：把 data.json 提交回仓库 main ————— */
   function b64utf8(s) {
@@ -934,17 +1005,20 @@
     tWrap.querySelectorAll(".t-chip").forEach(function (x) {
       x.classList.toggle("is-on", x.dataset.type === id);
     });
+    /* 「导进 NAS」只对碟片有意义 */
+    $("f-nas-row").style.display = (id === "disc") ? "flex" : "none";
   }
 
-  function openSheet(id) {
+  function openSheet(id, presetChar) {
     editingId = id || null;
     var it = id ? items.find(function (x) { return x.id === id; }) : null;
     $("sheet-title").textContent = it ? "改一改这件藏品" : "添加一件藏品";
     $("f-name").value = it ? it.name : "";
     $("f-spec").value = it ? (it.spec || "") : "";
-    $("f-char").value = it ? (it.charId || "") : "";
+    $("f-char").value = it ? (it.charId || "") : (presetChar || "");
     $("f-date").value = it ? (it.date || "") : "";
     $("f-note").value = it ? (it.note || "") : "";
+    $("f-nas").checked = it ? !!it.nas : false;
     $("f-signed").checked = it ? !!it.signed : false;
     $("f-wish").checked = it ? !!it.wish : false;
     setFormType(it ? it.type : "disc");
@@ -959,7 +1033,9 @@
   $("btn-cancel").addEventListener("click", closeSheet);
   $("overlay").addEventListener("click", function (e) { if (e.target === $("overlay")) closeSheet(); });
   document.addEventListener("keydown", function (e) {
-    if (e.key === "Escape" && $("overlay").classList.contains("is-on")) closeSheet();
+    if (e.key !== "Escape") return;
+    if ($("overlay").classList.contains("is-on")) closeSheet();
+    if ($("cm-overlay").classList.contains("is-on")) closeCharMenu();
   });
 
   $("btn-save").addEventListener("click", function () {
@@ -972,6 +1048,7 @@
       charId: $("f-char").value,
       date: $("f-date").value,
       note: $("f-note").value.trim(),
+      nas: (formType === "disc" && $("f-nas").checked) ? 1 : 0,
       signed: $("f-signed").checked ? 1 : 0,
       wish: $("f-wish").checked ? 1 : 0
     };


### PR DESCRIPTION
## 内容

- **NAS 追踪**：碟片类藏品新增「📡 已导进 NAS（Infuse 可看）」勾选（仅碟片显示），卡片带 📡 角标；筛选栏新增「已进 NAS / 还没进 NAS」；统计行新增「碟片进 NAS x / y」
- **角色格子交互调整**：馆长点画册地图任意格子弹出小菜单，「＋ 给他添一件藏品」（表单预选该角色）为首选，「只看他的藏品」「去画册」次之；访客行为不变
- 地图提示文案按访客 / 馆长身份分别显示；`data.json` 不动（保留线上最新收藏记录）

## 验证

Playwright 实测：NAS 勾选仅碟片显示、保存载荷含 `nas`/`charId`、📡 角标与两个新筛选正确、统计行「碟片进 NAS 0 / 2」准确；馆长菜单预选角色、暗格隐藏筛选项；访客点亮格仍为筛选、不弹菜单；无 JS 报错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6z5YXQYQuS8xyouAxCvBa

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6z5YXQYQuS8xyouAxCvBa)_