### PR TITLE
藏品架：碟片免起名（自动用电影名）＋ 保存缺信息弹明显提示

### DIFF
--- a/sam/shelf/index.html
+++ b/sam/shelf/index.html
@@ -544,8 +544,8 @@
   <div class="sheet" role="dialog" aria-modal="true" aria-label="添加或编辑藏品">
     <h2 id="sheet-title">添加一件藏品</h2>
 
-    <label class="f-label" for="f-name">它叫什么</label>
-    <input class="f-input" id="f-name" type="text" placeholder="例：《月球》蓝光 / Topps 签名卡…" maxlength="80">
+    <label class="f-label" for="f-name">它叫什么 <small id="f-name-hint"></small></label>
+    <input class="f-input" id="f-name" type="text" placeholder="" maxlength="80">
 
     <label class="f-label">它是哪一类</label>
     <div class="types" id="f-types"></div>
@@ -1014,6 +1014,31 @@
     $("f-nas-row").style.display = isDisc ? "flex" : "none";
     $("f-fmt-row").style.display = isDisc ? "flex" : "none";
     $("f-region-row").style.display = isDisc ? "flex" : "none";
+    updateNameHint();
+  }
+
+  /* 碟片不用起名：选了角色就自动用电影名 */
+  function autoDiscName() {
+    var c = charById[$("f-char").value];
+    if (!c) return "";
+    return c.filmCN || ("《" + c.film + "》");
+  }
+  function updateNameHint() {
+    var hint = $("f-name-hint");
+    var input = $("f-name");
+    if (formType === "disc") {
+      var auto = autoDiscName();
+      if (auto) {
+        hint.textContent = "（可不填 · 不填就叫「" + auto + "」）";
+        input.placeholder = auto + "（自动用电影名，想改再填）";
+      } else {
+        hint.textContent = "（可不填 · 选了关联角色就自动用电影名）";
+        input.placeholder = "例：《月球》蓝光…";
+      }
+    } else {
+      hint.textContent = "";
+      input.placeholder = "例：Topps 签名卡 / 亚克力立牌…";
+    }
   }
 
   /* ————— 碟片的制式 / 版本点选（单选可取消，落进 spec 字符串） ————— */
@@ -1096,6 +1121,7 @@
   function closeSheet() { $("overlay").classList.remove("is-on"); editingId = null; }
 
   $("add-btn").addEventListener("click", function () { openSheet(null); });
+  $("f-char").addEventListener("change", updateNameHint);
   $("btn-cancel").addEventListener("click", closeSheet);
   $("overlay").addEventListener("click", function (e) { if (e.target === $("overlay")) closeSheet(); });
   document.addEventListener("keydown", function (e) {
@@ -1106,7 +1132,12 @@
 
   $("btn-save").addEventListener("click", function () {
     var name = $("f-name").value.trim();
-    if (!name) { $("f-name").focus(); $("f-name").placeholder = "先给它起个名字呀"; return; }
+    if (!name && formType === "disc") name = autoDiscName();
+    if (!name) {
+      toast(formType === "disc" ? "选一个关联角色，或给它起个名字～" : "先给它起个名字呀");
+      $("f-name").focus();
+      return;
+    }
     var data = {
       name: name,
       type: formType,


### PR DESCRIPTION
## 内容

- 碟片不填名字时自动用关联角色的电影名（`filmCN`）做名字；名字栏提示与占位文字随所选角色实时更新；手填则优先
- 修复「点摆上架子没反应」：缺名字改为弹 toast 明确提示（碟片：「选一个关联角色，或给它起个名字」）
- 非碟片类型仍需名字，占位示例按类型区分

## 验证

Playwright 实测：碟片空名保存弹提示；选 Billy 后提示「不填就叫《七个神经病》」、保存名字自动为电影名（spec / charId 正确）；周边空名仍提示起名；无 JS 报错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6z5YXQYQuS8xyouAxCvBa

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6z5YXQYQuS8xyouAxCvBa)_