### PR TITLE
Fix chapter-card summary truncation from mood-tag column

### DIFF
--- a/_sass/5-components/_extras.scss
+++ b/_sass/5-components/_extras.scss
@@ -1600,7 +1600,10 @@
   line-height: 1.75;
   color: $ink-soft;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  /* 3 行：右侧 mood 标签栏（.c-chapter-card__aside）挤窄了正文列，
+     ≤35 字的 summary 在窄列里排到第 3 行才收得下——给足 3 行，
+     保持原本 35 字上限也能完整显示，无需回炉缩写任何一篇。 */
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }


### PR DESCRIPTION
The mood-tag aside column on series chapter cards narrowed the text body, so within-limit (≤35 char) summaries no longer fit in 2 lines and got clamped mid-sentence.

Fix: bump `.c-chapter-card__summary` line-clamp from 2 to 3 in `_sass/5-components/_extras.scss`. Existing summaries now display in full — no summary rewrites needed, the ≤35 char limit stays unchanged.

Verified against the chapters in the report (34/32/32 chars) — all now show complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PXfsQSgfGtYfGTeMyHgLk

---
_Generated by [Claude Code](https://claude.ai/code/session_012PXfsQSgfGtYfGTeMyHgLk)_